### PR TITLE
Add scaling and integration test

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   promote-charm:
-    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@8892eb826818585b397295e40276ddd0c5d3d459
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,5 +5,5 @@ on:
 
 jobs:
   unit-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@8892eb826818585b397295e40276ddd0c5d3d459
     secrets: inherit

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   publish-to-edge:
-    uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@8892eb826818585b397295e40276ddd0c5d3d459
     secrets: inherit
     with:
       integration-test-provider: microk8s

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,5 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+restart:
+  description: Restart the Temporal Web UI.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -50,14 +50,15 @@ async def scale(ops_test: OpsTest, app, units):
     await ops_test.model.applications[app].scale(scale=units)
 
     # Wait for model to settle
-    await ops_test.model.wait_for_idle(
-        apps=[app],
-        status="active",
-        idle_period=30,
-        raise_on_error=False,
-        raise_on_blocked=True,
-        timeout=300,
-        wait_for_exact_units=units,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[app],
+            status="active",
+            idle_period=30,
+            raise_on_error=False,
+            raise_on_blocked=True,
+            timeout=600,
+            wait_for_exact_units=units,
+        )
 
-    assert len(ops_test.model.applications[app].units) == units
+        assert len(ops_test.model.applications[app].units) == units

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,6 +4,7 @@
 
 """Temporal UI charm integration tests."""
 
+import asyncio
 import logging
 import socket
 import unittest.mock
@@ -29,10 +30,12 @@ APP_NAME_ADMIN = "temporal-admin-k8s"
 async def deploy(ops_test: OpsTest):
     """The app is up and running."""
     # Deploy temporal server, temporal admin and postgresql charms.
-    await ops_test.model.deploy(APP_NAME_SERVER, channel="stable")
-    await ops_test.model.deploy(APP_NAME_ADMIN, channel="stable")
-    await ops_test.model.deploy("postgresql-k8s", channel="edge", trust=True)
-    await ops_test.model.deploy("nginx-ingress-integrator", trust=True)
+    asyncio.gather(
+        ops_test.model.deploy(APP_NAME_SERVER, channel="stable"),
+        ops_test.model.deploy(APP_NAME_ADMIN, channel="stable"),
+        ops_test.model.deploy("postgresql-k8s", channel="14", trust=True),
+        ops_test.model.deploy("nginx-ingress-integrator", channel="edge", revision=71, trust=True),
+    )
 
     charm = await ops_test.build_charm(".")
     resources = {"temporal-ui-image": METADATA["containers"]["temporal-ui"]["upstream-source"]}
@@ -106,28 +109,35 @@ class TestDeployment:
         new_hostname = "temporal-web"
         application = ops_test.model.applications[APP_NAME]
         await application.set_config({"external-hostname": new_hostname})
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, "nginx-ingress-integrator"], status="active", raise_on_blocked=False, timeout=600
-        )
-        with unittest.mock.patch.multiple(socket, getaddrinfo=gen_patch_getaddrinfo(new_hostname, "127.0.0.1")):
-            response = requests.get(f"https://{new_hostname}", timeout=5, verify=False)  # nosec
-            assert response.status_code == 200 and 'id="svelte"' in response.text.lower()
+
+        async with ops_test.fast_forward():
+            await ops_test.model.wait_for_idle(
+                apps=[APP_NAME, "nginx-ingress-integrator"],
+                status="active",
+                raise_on_blocked=False,
+                idle_period=30,
+                timeout=1200,
+            )
+
+            with unittest.mock.patch.multiple(socket, getaddrinfo=gen_patch_getaddrinfo(new_hostname, "127.0.0.1")):
+                response = requests.get(f"https://{new_hostname}", timeout=5, verify=False)  # nosec
+                assert response.status_code == 200 and 'id="svelte"' in response.text.lower()
+
+    async def test_restart_action(self, ops_test: OpsTest):
+        """Test charm restart action."""
+        action = await ops_test.model.applications[APP_NAME].units[0].run_action("restart")
+        await action.wait()
+
+        async with ops_test.fast_forward():
+            await ops_test.model.wait_for_idle(
+                apps=[APP_NAME],
+                status="active",
+                raise_on_blocked=False,
+                timeout=600,
+            )
+
+            assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
     async def test_scaling_up(self, ops_test: OpsTest):
         """Scale Temporal worker charm up to 2 units."""
         await scale(ops_test, app=APP_NAME, units=2)
-
-        status = await ops_test.model.get_status()  # noqa: F821
-
-        for i in range(2):
-            address = status["applications"][APP_NAME]["units"][f"{APP_NAME}/{i}"]["address"]
-            url = f"http://{address}:8080"
-            logger.info("curling app address: %s", url)
-
-            response = requests.get(url, timeout=300)
-            assert response.status_code == 200
-
-        hostname = "temporal-web"
-        with unittest.mock.patch.multiple(socket, getaddrinfo=gen_patch_getaddrinfo(hostname, "127.0.0.1")):
-            response = requests.get(f"https://{hostname}", timeout=5, verify=False)  # nosec
-            assert response.status_code == 200 and 'id="svelte"' in response.text.lower()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -97,7 +97,7 @@ class TestCharm(TestCase):
             "service-name": harness.charm.app.name,
             "service-port": UI_PORT,
             "tls-secret-name": "temporal-tls",
-            "backend-protocol": "HTTPS",
+            "backend-protocol": "HTTP",
         }
 
         new_hostname = "new-temporal-ui-k8s"
@@ -110,7 +110,7 @@ class TestCharm(TestCase):
             "service-name": harness.charm.app.name,
             "service-port": UI_PORT,
             "tls-secret-name": "temporal-tls",
-            "backend-protocol": "HTTPS",
+            "backend-protocol": "HTTP",
         }
 
         new_tls = "new-tls"
@@ -123,7 +123,7 @@ class TestCharm(TestCase):
             "service-name": harness.charm.app.name,
             "service-port": UI_PORT,
             "tls-secret-name": new_tls,
-            "backend-protocol": "HTTPS",
+            "backend-protocol": "HTTP",
         }
 
     def test_ready(self):

--- a/tox.ini
+++ b/tox.ini
@@ -94,10 +94,9 @@ commands =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.1.0.1
+    juju==3.2.0.1
     pytest==7.1.3
     pytest-operator==0.22.0
-    temporalio==1.1.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
This PR slightly refactors the logic in the relation hooks with the Temporal server to enable the web UI charm to scale.

Ingress `backend-protocol` has also been reverted to HTTP to terminate the TLS at the ingress level.