### PR TITLE
CSS-3634: Upgrade resource to v2.21.3

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,7 +44,7 @@ options:
   auth-provider-url:
     description: |
         The .well-known IDP discovery URL for authentication and authorization.
-    default: ""
+    default: "https://accounts.google.com"
     type: string
   auth-client-id:
     description: |
@@ -61,3 +61,43 @@ options:
         The comma-separated array of resources required to be accessed from the access token.
     default: "[openid,profile,email]"
     type: string
+  codec-endpoint:
+    description: |
+        The endpoint for the Codec Server, if configured.
+    default: ""
+    type: string
+  codec-pass-access-token:
+    description: |
+        Whether to send a JWT access token as "authorization" header in requests with the Codec Server.
+    default: False
+    type: boolean
+  workflow-terminate-disabled:
+    description: |
+        Whether or not workflow termination is disabled through the UI.
+    default: False
+    type: boolean
+  workflow-cancel-disabled:
+    description: |
+        Whether or not workflow cancellation is disabled through the UI.
+    default: False
+    type: boolean
+  workflow-signal-disabled:
+    description: |
+        Whether or not workflow signals are disabled through the UI.
+    default: False
+    type: boolean
+  workflow-reset-disabled:
+    description: |
+        Whether or not workflow resetting is disabled through the UI.
+    default: False
+    type: boolean
+  batch-actions-disabled:
+    description: |
+        Whether or not batch actions are disabled through the UI.
+    default: False
+    type: boolean
+  hide-workflow-query-errors:
+    description: |
+        Whether or not workflow query errors are hidden on the UI.
+    default: False
+    type: boolean

--- a/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
+++ b/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
@@ -86,7 +86,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 __all__ = ["require_nginx_route", "provide_nginx_route"]
 
@@ -172,7 +172,8 @@ class _NginxRouteRequirer(ops.framework.Object):
 
 # C901 is ignored since the method has too many ifs but wouldn't be
 # necessarily good to reduce to smaller methods.
-def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches # noqa: C901
+# E501: line too long
+def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,too-many-arguments # noqa: C901,E501
     *,
     charm: ops.charm.CharmBase,
     service_hostname: str,

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -47,7 +47,7 @@ containers:
   temporal-ui:
     resource: temporal-ui-image
     # Included for simplicity in integration tests.
-    upstream-source: temporalio/ui:2.10.3
+    upstream-source: temporalio/ui:2.21.3
 
 resources:
   temporal-ui-image:

--- a/src/charm.py
+++ b/src/charm.py
@@ -264,6 +264,14 @@ class TemporalUiK8SOperatorCharm(CharmBase):
             "port": "TEMPORAL_UI_PORT",
             "default-namespace": "TEMPORAL_DEFAULT_NAMESPACE",
             "auth-enabled": "TEMPORAL_AUTH_ENABLED",
+            "codec-endpoint": "TEMPORAL_CODEC_ENDPOINT",
+            "codec-pass-access-token": "TEMPORAL_CODEC_PASS_ACCESS_TOKEN",
+            "workflow-terminate-disabled": "TEMPORAL_WORKFLOW_TERMINATE_DISABLED",
+            "workflow-cancel-disabled": "TEMPORAL_WORKFLOW_CANCEL_DISABLED",
+            "workflow-signal-disabled": "TEMPORAL_WORKFLOW_SIGNAL_DISABLED",
+            "workflow-reset-disabled": "TEMPORAL_WORKFLOW_RESET_DISABLED",
+            "batch-actions-disabled": "TEMPORAL_BATCH_ACTIONS_DISABLED",
+            "hide-workflow-query-errors": "TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS",
         }
 
         context = {config_key: self.config[key] for key, config_key in options.items()}

--- a/templates/config.jinja
+++ b/templates/config.jinja
@@ -2,6 +2,12 @@ temporalGrpcAddress: {{ TEMPORAL_ADDRESS | default("temporal-k8s:7233") }}
 port: {{ TEMPORAL_UI_PORT | default("8080") }}
 enableUi: {{ TEMPORAL_UI_ENABLED | default("true") }}
 defaultNamespace: {{ TEMPORAL_DEFAULT_NAMESPACE | default("default") }}
+workflowTerminateDisabled: {{ TEMPORAL_WORKFLOW_TERMINATE_DISABLED | default("false") }}
+workflowCancelDisabled: {{ TEMPORAL_WORKFLOW_CANCEL_DISABLED | default("false") }}
+workflowSignalDisabled: {{ TEMPORAL_WORKFLOW_SIGNAL_DISABLED | default("false") }}
+workflowResetDisabled: {{ TEMPORAL_WORKFLOW_RESET_DISABLED | default("false") }}
+batchActionsDisabled: {{ TEMPORAL_BATCH_ACTIONS_DISABLED | default("false") }}
+hideWorkflowQueryErrors: {{ TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS | default("false") }}
 auth:
   enabled: {{ TEMPORAL_AUTH_ENABLED | default("false")}}
   providers:
@@ -12,3 +18,7 @@ auth:
       clientSecret: {{ TEMPORAL_AUTH_CLIENT_SECRET | default("") }}
       scopes: {{ TEMPORAL_AUTH_SCOPES | default("") }}
       callbackUrl: {{ TEMPORAL_AUTH_CALLBACK_URL | default("") }}
+codec:
+  endpoint: {{ TEMPORAL_CODEC_ENDPOINT | default("") }}
+  passAccessToken: {{ TEMPORAL_CODEC_PASS_ACCESS_TOKEN | default("false") }}
+  includeCredentials: {{ TEMPORAL_CODEC_INCLUDE_CREDENTIALS | default("false") }}

--- a/templates/config.jinja
+++ b/templates/config.jinja
@@ -1,24 +1,24 @@
 temporalGrpcAddress: {{ TEMPORAL_ADDRESS | default("temporal-k8s:7233") }}
 port: {{ TEMPORAL_UI_PORT | default("8080") }}
 enableUi: {{ TEMPORAL_UI_ENABLED | default("true") }}
-defaultNamespace: {{ TEMPORAL_DEFAULT_NAMESPACE | default("default") }}
-workflowTerminateDisabled: {{ TEMPORAL_WORKFLOW_TERMINATE_DISABLED | default("false") }}
-workflowCancelDisabled: {{ TEMPORAL_WORKFLOW_CANCEL_DISABLED | default("false") }}
-workflowSignalDisabled: {{ TEMPORAL_WORKFLOW_SIGNAL_DISABLED | default("false") }}
-workflowResetDisabled: {{ TEMPORAL_WORKFLOW_RESET_DISABLED | default("false") }}
-batchActionsDisabled: {{ TEMPORAL_BATCH_ACTIONS_DISABLED | default("false") }}
-hideWorkflowQueryErrors: {{ TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS | default("false") }}
+defaultNamespace: {{ TEMPORAL_DEFAULT_NAMESPACE }}
+workflowTerminateDisabled: {{ TEMPORAL_WORKFLOW_TERMINATE_DISABLED }}
+workflowCancelDisabled: {{ TEMPORAL_WORKFLOW_CANCEL_DISABLED }}
+workflowSignalDisabled: {{ TEMPORAL_WORKFLOW_SIGNAL_DISABLED }}
+workflowResetDisabled: {{ TEMPORAL_WORKFLOW_RESET_DISABLED }}
+batchActionsDisabled: {{ TEMPORAL_BATCH_ACTIONS_DISABLED }}
+hideWorkflowQueryErrors: {{ TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS }}
 auth:
-  enabled: {{ TEMPORAL_AUTH_ENABLED | default("false")}}
+  enabled: {{ TEMPORAL_AUTH_ENABLED }}
   providers:
     - label: Auth0 oidc # for internal use; in future may expose as button text
       type: oidc # for futureproofing; only oidc is supported today
-      providerUrl: {{ TEMPORAL_AUTH_PROVIDER_URL | default("") }}
-      clientId: {{ TEMPORAL_AUTH_CLIENT_ID | default("") }}
-      clientSecret: {{ TEMPORAL_AUTH_CLIENT_SECRET | default("") }}
-      scopes: {{ TEMPORAL_AUTH_SCOPES | default("") }}
-      callbackUrl: {{ TEMPORAL_AUTH_CALLBACK_URL | default("") }}
+      providerUrl: {{ TEMPORAL_AUTH_PROVIDER_URL }}
+      clientId: {{ TEMPORAL_AUTH_CLIENT_ID }}
+      clientSecret: {{ TEMPORAL_AUTH_CLIENT_SECRET }}
+      scopes: {{ TEMPORAL_AUTH_SCOPES }}
+      callbackUrl: {{ TEMPORAL_AUTH_CALLBACK_URL }}
 codec:
-  endpoint: {{ TEMPORAL_CODEC_ENDPOINT | default("") }}
-  passAccessToken: {{ TEMPORAL_CODEC_PASS_ACCESS_TOKEN | default("false") }}
-  includeCredentials: {{ TEMPORAL_CODEC_INCLUDE_CREDENTIALS | default("false") }}
+  endpoint: {{ TEMPORAL_CODEC_ENDPOINT }}
+  passAccessToken: {{ TEMPORAL_CODEC_PASS_ACCESS_TOKEN }}
+  includeCredentials: {{ TEMPORAL_CODEC_INCLUDE_CREDENTIALS }}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -140,6 +140,14 @@ class TestCharm(TestCase):
                         "TEMPORAL_UI_PORT": 8080,
                         "TEMPORAL_DEFAULT_NAMESPACE": "default",
                         "TEMPORAL_AUTH_ENABLED": False,
+                        "TEMPORAL_WORKFLOW_CANCEL_DISABLED": False,
+                        "TEMPORAL_WORKFLOW_RESET_DISABLED": False,
+                        "TEMPORAL_WORKFLOW_SIGNAL_DISABLED": False,
+                        "TEMPORAL_WORKFLOW_TERMINATE_DISABLED": False,
+                        "TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS": False,
+                        "TEMPORAL_CODEC_ENDPOINT": "",
+                        "TEMPORAL_CODEC_PASS_ACCESS_TOKEN": False,
+                        "TEMPORAL_BATCH_ACTIONS_DISABLED": False,
                     },
                     "on-check-failure": {"up": "ignore"},
                 }
@@ -187,14 +195,15 @@ class TestCharm(TestCase):
                         "TEMPORAL_AUTH_CLIENT_SECRET": "some-client-secret",
                         "TEMPORAL_AUTH_SCOPES": "[openid,profile,email]",
                         "TEMPORAL_AUTH_CALLBACK_URL": f"https://{harness.model.config['external-hostname']}/auth/sso/callback",
+                        "TEMPORAL_WORKFLOW_CANCEL_DISABLED": False,
+                        "TEMPORAL_WORKFLOW_RESET_DISABLED": False,
+                        "TEMPORAL_WORKFLOW_SIGNAL_DISABLED": False,
+                        "TEMPORAL_WORKFLOW_TERMINATE_DISABLED": False,
+                        "TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS": False,
+                        "TEMPORAL_CODEC_ENDPOINT": "",
+                        "TEMPORAL_CODEC_PASS_ACCESS_TOKEN": False,
+                        "TEMPORAL_BATCH_ACTIONS_DISABLED": False,
                     },
-                    # "checks": {
-                    #     "up": {
-                    #         "override": "replace",
-                    #         "period": "10s",
-                    #         "http": {"url": "http://localhost:8080/"},
-                    #     }
-                    # },
                     "on-check-failure": {"up": "ignore"},
                 }
             },


### PR DESCRIPTION
As part of upgrading the [Temporal server charm](https://github.com/canonical/temporal-k8s-operator) to v1.21.5, this PR upgrades the version of the ui to the newer version v2.21.3 which contains a number of additional features such as creating schedules. It also adds some additional configuration parameters including the codec server endpoint, which can be used to decrypt workflow parameters through the web UI.