### PR TITLE
Add proxy env variables

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -287,6 +287,19 @@ class TemporalUiK8SOperatorCharm(CharmBase):
                 {"TEMPORAL_AUTH_CALLBACK_URL": f"https://{self.config['external-hostname']}/auth/sso/callback"}
             )
 
+        http_proxy = os.environ.get("JUJU_CHARM_HTTP_PROXY")
+        https_proxy = os.environ.get("JUJU_CHARM_HTTPS_PROXY")
+        no_proxy = os.environ.get("JUJU_CHARM_NO_PROXY")
+
+        if http_proxy or https_proxy:
+            context.update(
+                {
+                    "HTTP_PROXY": http_proxy,
+                    "HTTPS_PROXY": https_proxy,
+                    "NO_PROXY": no_proxy,
+                }
+            )
+
         config = render("config.jinja", context)
         container.push("/home/ui-server/config/charm.yaml", config, make_dirs=True)
 


### PR DESCRIPTION
This PR updates the charm code to inject the following proxy environment variables set through `model-config` into the workload container:

- `juju-http-proxy`
- `juju-https-proxy`
- `juju-no-proxy`