### PR TITLE
Add pebble plan validation

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -182,8 +182,8 @@ class TemporalUiK8SOperatorCharm(CharmBase):
         """
         try:
             plan = container.get_plan().to_dict()
-            return bool(plan and plan["services"].get(self.name, {}).get("on-check-failure"))
-        except pebble.ConnectionError:
+            return bool(plan["services"][self.name]["on-check-failure"])
+        except (KeyError, pebble.ConnectionError):
             return False
 
     @log_event_handler(logger)


### PR DESCRIPTION
This PR adds a handler to reapply the pebble plan after a restart with the `pebble-ready` event to address this [bug](https://warthogs.atlassian.net/browse/CSS-6875) (See this [PR](https://github.com/canonical/superset-k8s-operator/pull/28) for reference).