### PR TITLE
ci,refactor: use standard issue templates for bugs and enhancements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report
-labels: ["Type: Bug", "Status: Triage"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:
@@ -46,7 +46,7 @@ body:
       description: >
         Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
         Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs 
-        at https://juju.is/docs/olm/juju-logs
+        at https://documentation.ubuntu.com/juju/latest/howto/manage-logs/
       render: shell
     validations:
       required: true
@@ -54,3 +54,4 @@ body:
     id: additional-context
     attributes:
       label: Additional context
+

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
@@ -1,6 +1,6 @@
 name: Enhancement Proposal
 description: File an enhancement proposal
-labels: ["Type: Enhancement", "Status: Triage"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
@@ -8,10 +8,26 @@ body:
         Thanks for taking the time to fill out this enhancement proposal! Before submitting your issue, please make
         sure there isn't already a prior issue concerning this. If there is, please join that discussion instead.
   - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem statement
+      description: >
+        State the problem and motivations with as much detail as possible.
+    validations:
+      required: true
+  - type: textarea
     id: enhancement-proposal
     attributes:
       label: Enhancement Proposal
       description: >
-        Describe the enhancement you would like to see in as much detail as needed.      
+        Describe the enhancement you would like to see that solves the problem stated before.
     validations:
       required: true
+  - type: textarea
+    id: what-needs-to-get-done
+    attributes:
+      label: What needs to get done?
+      description: >
+        Please provide a list of actions that need to get done for this enhancement.
+    validations:
+      required: false


### PR DESCRIPTION
All the Workflow Charmers repositories should have the same issue templates, that way the triage process can be done seamlessly, as well as the team can get enough and relevant information about issues.