### PR TITLE
[WF-80] Integrate with the newly published temporal ui rock

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -24,6 +24,8 @@ jobs:
           provider: microk8s
           microk8s-addons: "ingress storage dns rbac registry metallb:10.15.119.2-10.15.119.4"
           channel: 1.25-strict/stable
+      - name: Pack charm
+        run: charmcraft pack
       - name: Run integration tests
         run: tox -e integration -- -k ${{ matrix.modules }}
       - name: Dump logs

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,9 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tox-environments:
-          - integration
-          - integration-traefik
+        modules:
+          - test_charm.py
+          - test_refresh.py
+          - test_traefik_ingress.py
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -24,7 +25,7 @@ jobs:
           microk8s-addons: "ingress storage dns rbac registry metallb:10.15.119.2-10.15.119.4"
           channel: 1.25-strict/stable
       - name: Run integration tests
-        run: tox -e ${{ matrix.tox-environments }} -- --model testing
+        run: tox -e integration -- -k ${{ matrix.modules }}
       - name: Dump logs
         uses: canonical/charm-logdump-action@main
         if: failure()

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -50,7 +50,7 @@ containers:
   temporal-ui:
     resource: temporal-ui-image
     # Included for simplicity in integration tests.
-    upstream-source: temporalio/ui:2.27.1
+    upstream-source: ubuntu/temporal-ui:2.39-24.04_edge@sha256:f14a4b14f32a6850a78273a3796e7812ce5aa85cd2fee6853dba9f08547f5f68
 
 resources:
   temporal-ui-image:

--- a/src/charm.py
+++ b/src/charm.py
@@ -355,7 +355,7 @@ class TemporalUiK8SOperatorCharm(CharmBase):
             "services": {
                 self.name: {
                     "summary": "temporal ui",
-                    "command": "./ui-server --env charm start",
+                    "command": "ui-server --root /home/ui-server --env charm start",
                     "startup": "enabled",
                     "override": "replace",
                     # Including config values here so that a change in the

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,7 +20,7 @@ def juju(request: pytest.FixtureRequest):
         yield model
 
         if request.session.testsfailed:
-            log = model.debuglog(limit=1000)
+            log = model.debug_log(limit=1000)
             print(log, end="")
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,103 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Fixtures for jubilant tests."""
+
+import pathlib
+
+import jubilant
+import pytest
+import yaml
+
+
+@pytest.fixture(scope="module")
+def juju(request: pytest.FixtureRequest):
+    keep_models = bool(request.config.getoption("--keep-models"))
+
+    with jubilant.temp_model(keep=keep_models) as model:
+        model.wait_timeout = 10 * 60
+
+        yield model
+
+        if request.session.testsfailed:
+            log = model.debuglog(limit=1000)
+            print(log, end="")
+
+
+@pytest.fixture(scope="module")
+def ui_latest(juju: jubilant.Juju):
+    """Deploy temporal-ui from the latest track."""
+    juju.model_config(
+        values={
+            "update-status-hook-interval": "10s",
+        },
+    )
+
+    juju.deploy(
+        charm="postgresql-k8s",
+        app="postgresql-k8s",
+        channel="14/stable",
+        trust=True,
+        base="ubuntu@22.04",
+    )
+
+    juju.deploy(
+        charm="temporal-k8s",
+        app="temporal-k8s",
+        channel="1.23/edge",
+        config={
+            "num-history-shards": 1,
+        },
+        base="ubuntu@22.04",
+    )
+
+    juju.deploy(
+        charm="temporal-admin-k8s",
+        app="temporal-admin-k8s",
+        channel="1.23/edge",
+        base="ubuntu@22.04",
+    )
+
+    juju.deploy(
+        charm="temporal-ui-k8s",
+        app="temporal-ui-k8s",
+        channel="latest/stable",
+        base="ubuntu@22.04",
+    )
+
+    juju.wait(
+        lambda status: (
+            jubilant.all_active(status, "postgresql-k8s")
+            and jubilant.all_blocked(status, "temporal-k8s", "temporal-admin-k8s", "temporal-ui-k8s")
+        ),
+    )
+
+    juju.integrate("temporal-k8s:db", "postgresql-k8s:database")
+    juju.integrate("temporal-k8s:visibility", "postgresql-k8s:database")
+
+    juju.integrate("temporal-k8s:admin", "temporal-admin-k8s:admin")
+
+    juju.integrate("temporal-k8s:ui", "temporal-ui-k8s:ui")
+
+    juju.wait(jubilant.all_active)
+
+    return "temporal-ui-k8s"
+
+
+@pytest.fixture(scope="module")
+def charm_path() -> pathlib.Path:
+    """Returns the absolute path of the locally built ui-k8s charm."""
+    charm_dir = pathlib.Path(__file__).parent.parent.parent
+    charms = [p.absolute() for p in charm_dir.glob("*.charm")]
+    assert charms, "*.charm not found in project root"
+    assert len(charms) == 1, "More than one *.charm file found in project root, unsure which to use"
+    return charms[0]
+
+
+@pytest.fixture(scope="module")
+def charm_resources() -> dict:
+    """Resources to deploy the ui-k8s locally built charm."""
+    metadata = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
+    return {
+        "temporal-ui-image": metadata["containers"]["temporal-ui"]["upstream-source"],
+    }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,12 @@ import jubilant
 import pytest
 import yaml
 
+POSTGRESQL_K8S_CHANNEL = "14/stable"
+TEMPORAL_CHANNEL = "1.23/edge"
+
+METADATA = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
+TEMPORAL_UI_IMAGE = METADATA["resources"]["temporal-ui-image"]["upstream-source"]
+
 
 @pytest.fixture(scope="module")
 def juju(request: pytest.FixtureRequest):
@@ -24,9 +30,22 @@ def juju(request: pytest.FixtureRequest):
             print(log, end="")
 
 
-@pytest.fixture(scope="module")
-def ui_latest(juju: jubilant.Juju):
-    """Deploy temporal-ui from the latest track."""
+def deploy_temporal_stack(
+    juju: jubilant.Juju,
+    postgresql_channel: str = POSTGRESQL_K8S_CHANNEL,
+    temporal_server_channel: str = TEMPORAL_CHANNEL,
+    temporal_admin_channel: str = TEMPORAL_CHANNEL,
+    temporal_ui_channel: str = TEMPORAL_CHANNEL,
+):
+    """Helper function to deploy the temporal stack.
+
+    Args:
+        juju: jubilant Juju object
+        postgresql_channel: channel for postgresql-k8s
+        temporal_server_channel: channel for temporal-k8s
+        temporal_admin_channel: channel for temporal-admin-k8s
+        temporal_ui_channel: channel for temporal-ui-k8s
+    """
     juju.model_config(
         values={
             "update-status-hook-interval": "10s",
@@ -36,7 +55,7 @@ def ui_latest(juju: jubilant.Juju):
     juju.deploy(
         charm="postgresql-k8s",
         app="postgresql-k8s",
-        channel="14/stable",
+        channel=postgresql_channel,
         trust=True,
         base="ubuntu@22.04",
     )
@@ -44,7 +63,7 @@ def ui_latest(juju: jubilant.Juju):
     juju.deploy(
         charm="temporal-k8s",
         app="temporal-k8s",
-        channel="1.23/edge",
+        channel=temporal_server_channel,
         config={
             "num-history-shards": 1,
         },
@@ -54,14 +73,14 @@ def ui_latest(juju: jubilant.Juju):
     juju.deploy(
         charm="temporal-admin-k8s",
         app="temporal-admin-k8s",
-        channel="1.23/edge",
+        channel=temporal_admin_channel,
         base="ubuntu@22.04",
     )
 
     juju.deploy(
         charm="temporal-ui-k8s",
         app="temporal-ui-k8s",
-        channel="latest/stable",
+        channel=temporal_ui_channel,
         base="ubuntu@22.04",
     )
 
@@ -81,6 +100,12 @@ def ui_latest(juju: jubilant.Juju):
 
     juju.wait(jubilant.all_active)
 
+
+@pytest.fixture(scope="module")
+def ui_latest_track(juju: jubilant.Juju):
+    """Deploy the temporal stack with temporal-ui from the latest/edge track."""
+    deploy_temporal_stack(temporal_ui_channel="latest/edge")
+
     return "temporal-ui-k8s"
 
 
@@ -97,7 +122,6 @@ def charm_path() -> pathlib.Path:
 @pytest.fixture(scope="module")
 def charm_resources() -> dict:
     """Resources to deploy the ui-k8s locally built charm."""
-    metadata = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
     return {
-        "temporal-ui-image": metadata["containers"]["temporal-ui"]["upstream-source"],
+        "temporal-ui-image": TEMPORAL_UI_IMAGE,
     }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -104,7 +104,7 @@ def deploy_temporal_stack(
 @pytest.fixture(scope="module")
 def ui_latest_track(juju: jubilant.Juju):
     """Deploy the temporal stack with temporal-ui from the latest/edge track."""
-    deploy_temporal_stack(temporal_ui_channel="latest/edge")
+    deploy_temporal_stack(juju, temporal_ui_channel="latest/edge")
 
     return "temporal-ui-k8s"
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -31,8 +31,8 @@ async def deploy(ops_test: OpsTest):
     """The app is up and running."""
     # Deploy temporal server, temporal admin and postgresql charms.
     asyncio.gather(
-        ops_test.model.deploy(APP_NAME_SERVER, channel="stable", config={"num-history-shards": 1}),
-        ops_test.model.deploy(APP_NAME_ADMIN, channel="stable"),
+        ops_test.model.deploy(APP_NAME_SERVER, channel="1.23/edge", config={"num-history-shards": 1}),
+        ops_test.model.deploy(APP_NAME_ADMIN, channel="1.23/edge"),
         ops_test.model.deploy("postgresql-k8s", channel="14", trust=True),
         ops_test.model.deploy("nginx-ingress-integrator", channel="edge", revision=100, trust=True),
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -14,6 +14,7 @@ import pytest
 import pytest_asyncio
 import requests
 import yaml
+from conftest import POSTGRESQL_K8S_CHANNEL, TEMPORAL_CHANNEL
 from helpers import gen_patch_getaddrinfo, scale
 from pytest_operator.plugin import OpsTest
 
@@ -25,16 +26,20 @@ APP_NAME = METADATA["name"]
 APP_NAME_SERVER = "temporal-k8s"
 APP_NAME_ADMIN = "temporal-admin-k8s"
 
+NGINX_INGRESS_INTEGRATOR_CHANNEL = "latest/edge"
+
 
 @pytest_asyncio.fixture(name="deploy", scope="module")
 async def deploy(ops_test: OpsTest):
     """The app is up and running."""
     # Deploy temporal server, temporal admin and postgresql charms.
     asyncio.gather(
-        ops_test.model.deploy(APP_NAME_SERVER, channel="1.23/edge", config={"num-history-shards": 1}),
-        ops_test.model.deploy(APP_NAME_ADMIN, channel="1.23/edge"),
-        ops_test.model.deploy("postgresql-k8s", channel="14", trust=True),
-        ops_test.model.deploy("nginx-ingress-integrator", channel="edge", revision=100, trust=True),
+        ops_test.model.deploy(APP_NAME_SERVER, channel=TEMPORAL_CHANNEL, config={"num-history-shards": 1}),
+        ops_test.model.deploy(APP_NAME_ADMIN, channel=TEMPORAL_CHANNEL),
+        ops_test.model.deploy("postgresql-k8s", channel=POSTGRESQL_K8S_CHANNEL, trust=True),
+        ops_test.model.deploy(
+            "nginx-ingress-integrator", channel=NGINX_INGRESS_INTEGRATOR_CHANNEL, revision=100, trust=True
+        ),
     )
 
     charm = await ops_test.build_charm(".")

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -10,10 +10,10 @@ import jubilant
 logger = logging.getLogger(__name__)
 
 
-def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, ui_latest, charm_path, charm_resources):
+def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, ui_latest_track, charm_path, charm_resources):
     """Test to refresh from latest track to the 1.23 track."""
     juju.refresh(
-        ui_latest,
+        ui_latest_track,
         path=charm_path,
         resources=charm_resources,
     )

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Test to ensure successful refreshes from latest track to the 1.23 track."""
+
+import logging
+
+import jubilant
+
+logger = logging.getLogger(__name__)
+
+
+def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, ui_latest, charm_path, charm_resources):
+    """Test to refresh from latest track to the 1.23 track."""
+    juju.refresh(
+        ui_latest,
+        path=charm_path,
+        resources=charm_resources,
+    )
+    juju.wait(jubilant.all_active, error=jubilant.any_error)

--- a/tests/integration/test_traefik_ingress.py
+++ b/tests/integration/test_traefik_ingress.py
@@ -21,9 +21,9 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 TEMPORAL_SERVER = "temporal-k8s"
-TEMPORAL_SERVER_CHANNEL = "stable"
+TEMPORAL_SERVER_CHANNEL = "1.23/edge"
 TEMPORAL_ADMIN = "temporal-admin-k8s"
-TEMPORAL_ADMIN_CHANNEL = "stable"
+TEMPORAL_ADMIN_CHANNEL = "1.23/edge"
 POSTGRESQL_K8S = "postgresql-k8s"
 POSTGRESQL_K8S_CHANNEL = "14"
 POSTGRESQL_K8S_TRUST = True

--- a/tests/integration/test_traefik_ingress.py
+++ b/tests/integration/test_traefik_ingress.py
@@ -13,6 +13,7 @@ import pytest
 import pytest_asyncio
 import requests
 import yaml
+from conftest import POSTGRESQL_K8S_CHANNEL, TEMPORAL_CHANNEL
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -21,11 +22,8 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 TEMPORAL_SERVER = "temporal-k8s"
-TEMPORAL_SERVER_CHANNEL = "1.23/edge"
 TEMPORAL_ADMIN = "temporal-admin-k8s"
-TEMPORAL_ADMIN_CHANNEL = "1.23/edge"
 POSTGRESQL_K8S = "postgresql-k8s"
-POSTGRESQL_K8S_CHANNEL = "14"
 POSTGRESQL_K8S_TRUST = True
 TRAEFIK_K8S = "traefik-k8s"
 TRAEFIK_K8S_CHANNEL = "latest/stable"
@@ -37,8 +35,8 @@ async def deploy(ops_test: OpsTest):
     """The app is up and running."""
     # Deploy temporal server, temporal admin, traefik-k8s, and postgresql charms.
     asyncio.gather(
-        ops_test.model.deploy(TEMPORAL_SERVER, channel=TEMPORAL_SERVER_CHANNEL, config={"num-history-shards": 1}),
-        ops_test.model.deploy(TEMPORAL_ADMIN, channel=TEMPORAL_ADMIN_CHANNEL),
+        ops_test.model.deploy(TEMPORAL_SERVER, channel=TEMPORAL_CHANNEL, config={"num-history-shards": 1}),
+        ops_test.model.deploy(TEMPORAL_ADMIN, channel=TEMPORAL_CHANNEL),
         ops_test.model.deploy(POSTGRESQL_K8S, channel=POSTGRESQL_K8S_CHANNEL, trust=POSTGRESQL_K8S_TRUST),
         ops_test.model.deploy(TRAEFIK_K8S, channel=TRAEFIK_K8S_CHANNEL, trust=TRAEFIK_K8S_TRUST),
     )

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -162,7 +162,7 @@ def test_ready(context, state, temporal_ui_container, temporal_ui_container_init
         "services": {
             "temporal-ui": {
                 "summary": "temporal ui",
-                "command": "./ui-server --env charm start",
+                "command": "ui-server --root /home/ui-server --env charm start",
                 "startup": "enabled",
                 "override": "replace",
                 "environment": {
@@ -215,7 +215,7 @@ def test_auth(
             "services": {
                 "temporal-ui": {
                     "summary": "temporal ui",
-                    "command": "./ui-server --env charm start",
+                    "command": "ui-server --root /home/ui-server --env charm start",
                     "startup": "enabled",
                     "override": "replace",
                     "environment": {

--- a/tox.ini
+++ b/tox.ini
@@ -41,13 +41,13 @@ deps =
     pytest
     black==22.8.0
     codespell==2.2.1
-    flake8==5.0.4
+    flake8==7.0.0
     flake8-builtins==1.5.3
-    flake8-copyright==0.2.3
+    flake8-copyright==0.2.4
     flake8-docstrings==1.6.0
     isort==5.10.1
     pep8-naming==0.13.2
-    pyproject-flake8==5.0.4.post1
+    pyproject-flake8==7.0.0
     flake8-docstrings-complete>=1.0.3
     flake8-test-docs>=1.0
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -91,18 +91,6 @@ deps =
 commands =
     bandit -c {toxinidir}/pyproject.toml -r {[vars]src_path} {[vars]tst_path}
 
-[testenv:integration-traefik]
-description = Run integration with traefik tests
-deps =
-    ipdb==0.13.9
-    juju==3.6.1.2
-    pytest==7.1.3
-    pytest-asyncio==0.20.3
-    pytest-operator==0.22.0
-    -r{toxinidir}/requirements.txt
-commands =
-    pytest -v --tb native {[vars]tst_path}integration/test_traefik_ingress.py --ignore={[vars]tst_path}unit --ignore={[vars]tst_path}scenario --log-cli-level=INFO -s {posargs}
-
 [testenv:integration]
 description = Run integration tests
 deps =
@@ -111,6 +99,7 @@ deps =
     pytest==7.1.3
     pytest-asyncio==0.20.3
     pytest-operator==0.22.0
+    jubilant~=1.0
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native {[vars]tst_path}integration/test_charm.py --ignore={[vars]tst_path}unit --ignore={[vars]tst_path}scenario --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore={[vars]tst_path}unit --ignore={[vars]tst_path}scenario --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
We have implemented a new rock for temporal-ui (2.39.0).
This PR integrates with this rock.
As part of the integration, the temporal ui server version will be bumped up to 2.39.0.

Additionally, the CI machinery is modified to use one tox target, leveraging GH action matrixes to parametrize integration tests.
Also, a test (using jubilant) is added to ensure that refreshes of temporal-ui-k8s from the `latest` track to `2.39.0` successfully completes.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->
charmcraft pack
tox -e integration -- -k "test_charm.py"
tox -e integration -- -k "test_refresh.py"
tox -e integration -- -k "test_traefik_ingress.py"

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [x] Integration tests added or updated
- [ ] Documentation updated
