### PR TITLE
[WF-92] Enable static code analysis (TIOBE) scans

### DIFF
--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,0 +1,14 @@
+name: Tiobe TiCS Analysis
+
+on:
+    workflow_dispatch:
+    schedule:
+    - cron: "17 2 * * 1"  # Runs at 2:17 UTC every Monday
+
+jobs:
+    tics:
+        name: TiCs
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
+        with: 
+            coverage-folder: ".cover"
+        secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+[project]
+name = "temporal-ui-k8s-operator"
+version = "0.0"
+
 [tool.bandit]
 exclude_dirs = ["/venv/"]
 [tool.bandit.assert_used]


### PR DESCRIPTION
## Description
Adding static code analysis for the repo


---
## Testing instructions
The workflow is triggered automatically at Monday at 02:00 UTC or by manual trigger



---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
