### PR TITLE
[WF-334] Add temporal-host-info relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Please check the
 [Temporal server operator](https://charmhub.io/temporal-k8s)
 for usage instructions.
 
+### Temporal endpoint resolution
+
+`temporal-host-info` relation is the preferred source of Temporal server address.
+If relation data is unavailable, the deprecated `server-name` config option is
+used as a temporary fallback for upgrade compatibility.
+
+`server-name` is deprecated and will be removed in a future release. Prefer
+integrating `temporal-host-info` relation instead of relying on config fallback.
+
 ## Contributing
 
 This charm is still in active development. Please see the

--- a/README.md
+++ b/README.md
@@ -26,12 +26,9 @@ for usage instructions.
 
 ### Temporal endpoint resolution
 
-`temporal-host-info` relation is the preferred source of Temporal server address.
-If relation data is unavailable, the deprecated `server-name` config option is
-used as a temporary fallback for upgrade compatibility.
+`temporal-host-info` relation is the preferred source of Temporal server address. If relation data is unavailable, the deprecated `server-name` config option is used as a temporary fallback for upgrade compatibility.
 
-`server-name` is deprecated and will be removed in a future release. Prefer
-integrating `temporal-host-info` relation instead of relying on config fallback.
+`server-name` is deprecated and will be removed in a future release. Prefer integrating `temporal-host-info` relation instead of relying on config fallback.
 
 ## Contributing
 

--- a/config.yaml
+++ b/config.yaml
@@ -21,6 +21,13 @@ options:
         application.
     default: "temporal-ui-k8s"
     type: string
+  server-name:
+    description: |
+        [DEPRECATED] Optional fallback Temporal server hostname when `temporal-host-info` relation is unavailable.
+        Leave empty to require `temporal-host-info` only. If set, this option is deprecated and will be
+        removed in a future release; prefer the `temporal-host-info` relation as the source of truth.
+    default: ""
+    type: string
   tls-secret-name:
     description: |
         Name of the k8s secret which contains the TLS certificate to be used by ingress.

--- a/config.yaml
+++ b/config.yaml
@@ -21,13 +21,6 @@ options:
         application.
     default: "temporal-ui-k8s"
     type: string
-  server-name:
-    description: |
-        [DEPRECATED] Optional fallback Temporal server hostname when `temporal-host-info` relation is unavailable.
-        Leave empty to require `temporal-host-info` only. If set, this option is deprecated and will be
-        removed in a future release; prefer the `temporal-host-info` relation as the source of truth.
-    default: ""
-    type: string
   tls-secret-name:
     description: |
         Name of the k8s secret which contains the TLS certificate to be used by ingress.

--- a/lib/charms/temporal_k8s/v0/temporal_host_info.py
+++ b/lib/charms/temporal_k8s/v0/temporal_host_info.py
@@ -1,0 +1,177 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+from ops import (
+    ConfigChangedEvent,
+    Handle,
+    LeaderElectedEvent,
+    RelationChangedEvent,
+    RelationJoinedEvent,
+    framework,
+)
+from ops.charm import CharmBase
+from ops.framework import EventBase, EventSource, ObjectEvents
+from ops.model import ActiveStatus, Relation, WaitingStatus
+
+# The unique Charmhub library identifier, never change it
+LIBID = "024db27b47e546628c9ed7f26ddad6c8"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+RELATION_NAME = "temporal-host-info"
+
+logger = logging.getLogger(__name__)
+
+
+class TemporalHostInfoProvider(framework.Object):
+    """A class for managing the temporal-host-info interface provider."""
+
+    def __init__(self, charm: CharmBase, port: int):
+        """Create a new instance of the TemporalHostInfoProvider class.
+
+        :param: charm: The charm that is using this interface.
+        :type charm: CharmBase
+        :param: port: The port number to provide to requirers. This is typically
+            the 'frontend' service port.
+        :type port: int
+        """
+        super().__init__(charm, "temporal_host_info_provider")
+        self.charm = charm
+        self.port = port
+        charm.framework.observe(charm.on[RELATION_NAME].relation_joined, self._on_host_info_relation_changed)
+        charm.framework.observe(charm.on[RELATION_NAME].relation_changed, self._on_host_info_relation_changed)
+        charm.framework.observe(charm.on.leader_elected, self._on_config_changed)
+        charm.framework.observe(charm.on.config_changed, self._on_config_changed)
+
+    def _on_host_info_relation_changed(self, event: RelationChangedEvent | RelationJoinedEvent):
+        """Update relation data.
+
+        :param: event: The relation event that triggered this handler.
+        :type event: RelationChangedEvent | RelationJoinedEvent
+        """
+        logger.info("Handling temporal-host-info relation event")
+        if self.charm.unit.is_leader() and "frontend" in str(self.charm.config["services"]):
+            host = str(self.charm.config["external-hostname"])
+            if binding := self.charm.model.get_binding(event.relation):
+                host = host or str(binding.network.bind_address)
+            event.relation.data[self.charm.app]["host"] = host
+            event.relation.data[self.charm.app]["port"] = str(self.port)
+
+    def _on_config_changed(self, event: ConfigChangedEvent | LeaderElectedEvent):
+        """Update relation data on config change."""
+        logger.info("Config changed, updating temporal-host-info relation data")
+        if self.charm.unit.is_leader() and "frontend" in str(self.charm.config["services"]):
+            host = str(self.charm.config["external-hostname"])
+            for relation in self.charm.model.relations.get("temporal-host-info", []):
+                if binding := self.charm.model.get_binding(relation):
+                    host = host or str(binding.network.bind_address)
+                relation.data[self.charm.app]["host"] = host
+                relation.data[self.charm.app]["port"] = str(self.port)
+
+
+class TemporalHostInfoRelationReadyEvent(EventBase):
+    """Event emitted when temporal-host-info relation is ready."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        host: str,
+        port: int,
+    ):
+        super().__init__(handle)
+        self.host = host
+        self.port = port
+
+    def snapshot(self) -> dict[str, str | int]:
+        """Return a snapshot of the event."""
+        data = super().snapshot()
+        data.update({"host": self.host, "port": self.port})
+        return data
+
+    def restore(self, snapshot: dict[str, str | int]) -> None:
+        """Restore the event from a snapshot."""
+        super().restore(snapshot)
+        self.host = snapshot["host"]
+        self.port = snapshot["port"]
+
+
+class TemporalHostInfoRequirerCharmEvents(ObjectEvents):
+    """List of events that the requirer charm can leverage."""
+
+    temporal_host_info_available = EventSource(TemporalHostInfoRelationReadyEvent)
+
+
+class TemporalHostInfoRequirer(framework.Object):
+    """A class for managing the temporal-host-info interface requirer.
+
+    Track this relation in your charm with:
+
+    .. code-block:: python
+
+        self.host_info = TemporalHostInfoRequirer(self)
+        # update container with new host info
+        framework.observe(self.host_info.on.temporal_host_info_available, self._update)
+
+        def _update(self, event):
+            host = self.host_info.host
+            port = self.host_info.port
+    """
+
+    on = TemporalHostInfoRequirerCharmEvents()  # type: ignore[reportAssignmentType]
+
+    def __init__(self, charm: CharmBase):
+        """Create a new instance of the TemporalHostInfoProvider class.
+
+        :param: charm: The charm that is using this interface.
+        :type charm: CharmBase
+        """
+        super().__init__(charm, "temporal_host_info_requirer")
+        self.charm = charm
+        charm.framework.observe(charm.on[RELATION_NAME].relation_joined, self._on_host_info_relation_changed)
+        charm.framework.observe(charm.on[RELATION_NAME].relation_changed, self._on_host_info_relation_changed)
+
+    @property
+    def relations(self) -> list[Relation]:
+        """Return the relations for this interface."""
+        return self.charm.model.relations.get(RELATION_NAME, [])
+
+    @property
+    def host(self) -> str | None:
+        """Return the host from the relation data."""
+        for relation in self.relations:
+            if relation and relation.app:
+                return relation.data[relation.app].get("host", None)
+        return None
+
+    @property
+    def port(self) -> int | None:
+        """Return the port from the relation data."""
+        for relation in self.relations:
+            if relation and relation.app:
+                port_str = relation.data[relation.app].get("port", None)
+                if port_str is not None:
+                    return int(port_str)
+        return None
+
+    def _on_host_info_relation_changed(self, event: RelationChangedEvent):
+        """Handle the relation joined/changed events.
+
+        :param: event: The relation event that triggered this handler.
+        :type event: RelationChangedEvent | RelationJoinedEvent
+        """
+        try:
+            host = event.relation.data[event.relation.app]["host"]
+            port = int(event.relation.data[event.relation.app]["port"])
+        except KeyError:
+            self.charm.unit.status = WaitingStatus("Waiting for temporal-host-info provider")
+            event.defer()
+            return
+        self.charm.unit.status = ActiveStatus()
+        self.on.temporal_host_info_available.emit(host=host, port=port)

--- a/lib/charms/temporal_k8s/v0/temporal_host_info.py
+++ b/lib/charms/temporal_k8s/v0/temporal_host_info.py
@@ -1,5 +1,12 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
+
+"""Charm library for the temporal-host-info relation interface.
+
+This library provides the TemporalHostInfoProvider and TemporalHostInfoRequirer
+classes for charms that need to share Temporal server connection details
+(host and port) over a Juju relation.
+"""
 
 import logging
 
@@ -7,13 +14,15 @@ from ops import (
     ConfigChangedEvent,
     Handle,
     LeaderElectedEvent,
+    Object,
+    RelationBrokenEvent,
     RelationChangedEvent,
     RelationJoinedEvent,
-    framework,
+    TooManyRelatedAppsError,
 )
 from ops.charm import CharmBase
 from ops.framework import EventBase, EventSource, ObjectEvents
-from ops.model import ActiveStatus, Relation, WaitingStatus
+from ops.model import Relation
 
 # The unique Charmhub library identifier, never change it
 LIBID = "024db27b47e546628c9ed7f26ddad6c8"
@@ -30,7 +39,7 @@ RELATION_NAME = "temporal-host-info"
 logger = logging.getLogger(__name__)
 
 
-class TemporalHostInfoProvider(framework.Object):
+class TemporalHostInfoProvider(Object):
     """A class for managing the temporal-host-info interface provider."""
 
     def __init__(self, charm: CharmBase, port: int):
@@ -56,28 +65,49 @@ class TemporalHostInfoProvider(framework.Object):
         :param: event: The relation event that triggered this handler.
         :type event: RelationChangedEvent | RelationJoinedEvent
         """
-        logger.info("Handling temporal-host-info relation event")
-        if self.charm.unit.is_leader() and "frontend" in str(self.charm.config["services"]):
-            host = str(self.charm.config["external-hostname"])
-            if binding := self.charm.model.get_binding(event.relation):
-                host = host or str(binding.network.bind_address)
-            event.relation.data[self.charm.app]["host"] = host
-            event.relation.data[self.charm.app]["port"] = str(self.port)
+        logger.debug("Handling temporal-host-info relation event")
+        if not self.charm.unit.is_leader() or "frontend" not in str(self.charm.config["services"]):
+            return
+        host = self._resolve_host(event.relation)
+        app_data = event.relation.data[self.charm.app]
+        app_data["host"] = host
+        app_data["port"] = str(self.port)
 
     def _on_config_changed(self, event: ConfigChangedEvent | LeaderElectedEvent):
-        """Update relation data on config change."""
-        logger.info("Config changed, updating temporal-host-info relation data")
-        if self.charm.unit.is_leader() and "frontend" in str(self.charm.config["services"]):
-            host = str(self.charm.config["external-hostname"])
-            for relation in self.charm.model.relations.get("temporal-host-info", []):
-                if binding := self.charm.model.get_binding(relation):
-                    host = host or str(binding.network.bind_address)
-                relation.data[self.charm.app]["host"] = host
-                relation.data[self.charm.app]["port"] = str(self.port)
+        """Update relation data on config change or leader election.
+
+        :param: event: The event that triggered this handler.
+        :type event: ConfigChangedEvent | LeaderElectedEvent
+        """
+        logger.debug("Config changed, updating temporal-host-info relation data")
+        if not self.charm.unit.is_leader() or "frontend" not in str(self.charm.config["services"]):
+            return
+        for relation in self.charm.model.relations.get(RELATION_NAME, []):
+            host = self._resolve_host(relation)
+            app_data = relation.data[self.charm.app]
+            app_data["host"] = host
+            app_data["port"] = str(self.port)
+
+    def _resolve_host(self, relation: Relation) -> str:
+        """Resolve host to external-hostname or relation binding address.
+
+        :param: relation: The relation to resolve the host for.
+        :type relation: Relation
+        :returns: The resolved host string.
+        :rtype: str
+        """
+        host = str(self.charm.config["external-hostname"])
+        if not host:
+            binding = self.charm.model.get_binding(relation)
+            if binding:
+                host = str(binding.network.bind_address)
+        if not host:
+            logger.warning("Could not resolve host: external-hostname is not set and no binding address is available")
+        return host
 
 
-class TemporalHostInfoRelationReadyEvent(EventBase):
-    """Event emitted when temporal-host-info relation is ready."""
+class TemporalHostInfoChangedEvent(EventBase):
+    """Event emitted when temporal-host-info relation data changes."""
 
     def __init__(
         self,
@@ -105,10 +135,12 @@ class TemporalHostInfoRelationReadyEvent(EventBase):
 class TemporalHostInfoRequirerCharmEvents(ObjectEvents):
     """List of events that the requirer charm can leverage."""
 
-    temporal_host_info_available = EventSource(TemporalHostInfoRelationReadyEvent)
+    temporal_host_info_changed = EventSource(TemporalHostInfoChangedEvent)
+    # No data to snapshot/restore here, so we can just use EventBase
+    temporal_host_info_unavailable = EventSource(EventBase)
 
 
-class TemporalHostInfoRequirer(framework.Object):
+class TemporalHostInfoRequirer(Object):
     """A class for managing the temporal-host-info interface requirer.
 
     Track this relation in your charm with:
@@ -117,9 +149,9 @@ class TemporalHostInfoRequirer(framework.Object):
 
         self.host_info = TemporalHostInfoRequirer(self)
         # update container with new host info
-        framework.observe(self.host_info.on.temporal_host_info_available, self._update)
+        framework.observe(self.host_info.on.temporal_host_info_changed, self._on_host_info_changed)
 
-        def _update(self, event):
+        def _on_host_info_changed(self, event):
             host = self.host_info.host
             port = self.host_info.port
     """
@@ -127,51 +159,62 @@ class TemporalHostInfoRequirer(framework.Object):
     on = TemporalHostInfoRequirerCharmEvents()  # type: ignore[reportAssignmentType]
 
     def __init__(self, charm: CharmBase):
-        """Create a new instance of the TemporalHostInfoProvider class.
+        """Create a new instance of the TemporalHostInfoRequirer class.
 
         :param: charm: The charm that is using this interface.
         :type charm: CharmBase
         """
         super().__init__(charm, "temporal_host_info_requirer")
         self.charm = charm
+        try:
+            self.charm.model.get_relation(RELATION_NAME)
+        except TooManyRelatedAppsError:
+            raise RuntimeError(f"Multiple {RELATION_NAME} relations are not supported for requirers.")
         charm.framework.observe(charm.on[RELATION_NAME].relation_joined, self._on_host_info_relation_changed)
         charm.framework.observe(charm.on[RELATION_NAME].relation_changed, self._on_host_info_relation_changed)
+        charm.framework.observe(charm.on[RELATION_NAME].relation_broken, self._on_host_info_relation_broken)
 
     @property
-    def relations(self) -> list[Relation]:
-        """Return the relations for this interface."""
-        return self.charm.model.relations.get(RELATION_NAME, [])
+    def relation(self) -> Relation | None:
+        """Return the relation for this interface, if any."""
+        return self.charm.model.get_relation(RELATION_NAME)
 
     @property
     def host(self) -> str | None:
         """Return the host from the relation data."""
-        for relation in self.relations:
-            if relation and relation.app:
-                return relation.data[relation.app].get("host", None)
+        relation = self.relation
+        if relation and relation.app:
+            return relation.data[relation.app].get("host", None)
         return None
 
     @property
     def port(self) -> int | None:
         """Return the port from the relation data."""
-        for relation in self.relations:
-            if relation and relation.app:
-                port_str = relation.data[relation.app].get("port", None)
-                if port_str is not None:
-                    return int(port_str)
+        relation = self.relation
+        if relation and relation.app:
+            port_str = relation.data[relation.app].get("port", None)
+            if port_str is not None:
+                return int(port_str)
         return None
 
-    def _on_host_info_relation_changed(self, event: RelationChangedEvent):
+    def _on_host_info_relation_broken(self, event: RelationBrokenEvent):
+        """Handle the relation broken event.
+
+        :param: event: The relation broken event that triggered this handler.
+        :type event: RelationBrokenEvent
+        """
+        self.on.temporal_host_info_unavailable.emit()
+
+    def _on_host_info_relation_changed(self, event: RelationChangedEvent | RelationJoinedEvent):
         """Handle the relation joined/changed events.
 
         :param: event: The relation event that triggered this handler.
         :type event: RelationChangedEvent | RelationJoinedEvent
         """
+        app_data = event.relation.data[event.relation.app]
         try:
-            host = event.relation.data[event.relation.app]["host"]
-            port = int(event.relation.data[event.relation.app]["port"])
+            host = app_data["host"]
+            port = int(app_data["port"])
         except KeyError:
-            self.charm.unit.status = WaitingStatus("Waiting for temporal-host-info provider")
-            event.defer()
             return
-        self.charm.unit.status = ActiveStatus()
-        self.on.temporal_host_info_available.emit(host=host, port=port)
+        self.on.temporal_host_info_changed.emit(host=host, port=port)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -44,6 +44,7 @@ requires:
     limit: 1
   ingress:
     interface: ingress
+    limit: 1
   temporal-host-info:
     interface: temporal-host-info
     limit: 1

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,11 +9,11 @@ display-name: Temporal Web UI
 summary: Temporal Web UI operator
 description: |
   Temporal is a developer-first, open source platform that ensures
-  the successful execution of services and applications (using workflows). 
-  
-  This charm provides the web UI which can be related to the Temporal server 
+  the successful execution of services and applications (using workflows).
+
+  This charm provides the web UI which can be related to the Temporal server
   charm to view workflow runs.
-maintainers: 
+maintainers:
   - Commercial Systems <jaas-crew@lists.canonical.com>
 source: https://github.com/canonical/temporal-ui-k8s-operator
 docs: https://discourse.charmhub.io/t/temporal-ui-documentation-overview/9232
@@ -44,6 +44,8 @@ requires:
     limit: 1
   ingress:
     interface: ingress
+  temporal-host-info:
+    interface: temporal-host-info
     limit: 1
 
 containers:

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,8 +10,8 @@ import logging
 import os
 
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
-from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from charms.temporal_k8s.v0.temporal_host_info import TemporalHostInfoRequirer
+from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from jinja2 import Environment, FileSystemLoader
 from ops import main, pebble
 from ops.charm import CharmBase
@@ -94,7 +94,7 @@ class TemporalUiK8SOperatorCharm(CharmBase):
         self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
 
         self.host_info = TemporalHostInfoRequirer(self)
-        self.framework.observe(self.host_info.on.temporal_host_info_available, self._update)
+        self.framework.observe(self.host_info.on.temporal_host_info_changed, self._update)
 
     def _require_nginx_route(self):
         """Require nginx-route relation based on current configuration."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,11 +11,13 @@ import os
 
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
 from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
+from charms.temporal_k8s.v0.temporal_host_info import TemporalHostInfoRequirer
 from jinja2 import Environment, FileSystemLoader
 from ops import main, pebble
 from ops.charm import CharmBase
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import CheckStatus
+
 
 from log import log_event_handler
 from state import State
@@ -91,6 +93,9 @@ class TemporalUiK8SOperatorCharm(CharmBase):
         )
         self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
         self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
+
+        self.host_info = TemporalHostInfoRequirer(self)
+        self.framework.observe(self.host_info.on.temporal_host_info_available, self._update)
 
     def _require_nginx_route(self):
         """Require nginx-route relation based on current configuration."""
@@ -354,6 +359,9 @@ class TemporalUiK8SOperatorCharm(CharmBase):
                     "NO_PROXY": no_proxy,
                 }
             )
+
+        if self.host_info.host and self.host_info.port:
+            context["TEMPORAL_ADDRESS"] = f"{self.host_info.host}:{self.host_info.port}"
 
         config = render("config.jinja", context)
         container.push("/home/ui-server/config/charm.yaml", config, make_dirs=True)

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,7 +18,6 @@ from ops.charm import CharmBase
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import CheckStatus
 
-
 from log import log_event_handler
 from state import State
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -56,15 +56,6 @@ class TemporalUiK8SOperatorCharm(CharmBase):
         """Return the DNS listing used for external connections."""
         return self.config["external-hostname"] or self.app.name
 
-    @property
-    def _deprecated_server_name(self) -> str | None:
-        """Return configured fallback Temporal server hostname, if set."""
-        raw = self.config.get("server-name")
-        if raw is None:
-            return None
-        stripped = str(raw).strip()
-        return stripped or None
-
     def __init__(self, *args):
         """Construct.
 
@@ -369,23 +360,11 @@ class TemporalUiK8SOperatorCharm(CharmBase):
                 }
             )
 
-        # Relation data is authoritative when available. For upgrade compatibility,
-        # fallback to the deprecated `server-name` config until it is removed.
-        if self.host_info.host and self.host_info.port:
-            context["TEMPORAL_ADDRESS"] = f"{self.host_info.host}:{self.host_info.port}"
-        else:
-            deprecated = self._deprecated_server_name
-            if deprecated:
-                logger.warning(
-                    "Config option `server-name` is deprecated and will be removed in a future release; "
-                    "prefer the `temporal-host-info` relation."
-                )
-                context["TEMPORAL_ADDRESS"] = f"{deprecated}:7233"
-            else:
-                self.unit.status = BlockedStatus(
-                    "temporal-host-info relation not established; set deprecated server-name config as fallback"
-                )
-                return
+        if not (self.host_info.host and self.host_info.port):
+            self.unit.status = BlockedStatus("temporal-host-info relation not established")
+            return
+
+        context["TEMPORAL_ADDRESS"] = f"{self.host_info.host}:{self.host_info.port}"
 
         config = render("config.jinja", context)
         container.push("/home/ui-server/config/charm.yaml", config, make_dirs=True)

--- a/src/charm.py
+++ b/src/charm.py
@@ -56,6 +56,15 @@ class TemporalUiK8SOperatorCharm(CharmBase):
         """Return the DNS listing used for external connections."""
         return self.config["external-hostname"] or self.app.name
 
+    @property
+    def _deprecated_server_name(self) -> str | None:
+        """Return configured fallback Temporal server hostname, if set."""
+        raw = self.config.get("server-name")
+        if raw is None:
+            return None
+        stripped = str(raw).strip()
+        return stripped or None
+
     def __init__(self, *args):
         """Construct.
 
@@ -95,6 +104,7 @@ class TemporalUiK8SOperatorCharm(CharmBase):
 
         self.host_info = TemporalHostInfoRequirer(self)
         self.framework.observe(self.host_info.on.temporal_host_info_changed, self._update)
+        self.framework.observe(self.host_info.on.temporal_host_info_unavailable, self._update)
 
     def _require_nginx_route(self):
         """Require nginx-route relation based on current configuration."""
@@ -359,8 +369,23 @@ class TemporalUiK8SOperatorCharm(CharmBase):
                 }
             )
 
+        # Relation data is authoritative when available. For upgrade compatibility,
+        # fallback to the deprecated `server-name` config until it is removed.
         if self.host_info.host and self.host_info.port:
             context["TEMPORAL_ADDRESS"] = f"{self.host_info.host}:{self.host_info.port}"
+        else:
+            deprecated = self._deprecated_server_name
+            if deprecated:
+                logger.warning(
+                    "Config option `server-name` is deprecated and will be removed in a future release; "
+                    "prefer the `temporal-host-info` relation."
+                )
+                context["TEMPORAL_ADDRESS"] = f"{deprecated}:7233"
+            else:
+                self.unit.status = BlockedStatus(
+                    "temporal-host-info relation not established; set deprecated server-name config as fallback"
+                )
+                return
 
         config = render("config.jinja", context)
         container.push("/home/ui-server/config/charm.yaml", config, make_dirs=True)

--- a/src/charm.py
+++ b/src/charm.py
@@ -191,7 +191,8 @@ class TemporalUiK8SOperatorCharm(CharmBase):
         """
         try:
             self._validate()
-        except ValueError:
+        except ValueError as err:
+            self.unit.status = BlockedStatus(str(err))
             return
 
         container = self.unit.get_container(self.name)
@@ -289,6 +290,8 @@ class TemporalUiK8SOperatorCharm(CharmBase):
             raise ValueError("ui:temporal relation: not available")
         if not self._state.server_status == "ready":
             raise ValueError("ui:temporal relation: server is not ready")
+        if not (self.host_info.host and self.host_info.port):
+            raise ValueError("temporal-host-info relation not established")
         if self.model.relations.get("ingress") and self.model.relations.get("nginx-route"):
             raise ValueError("Only one ingress solution is allowed - remove the ingress or the nginx-route relation")
 

--- a/templates/config.jinja
+++ b/templates/config.jinja
@@ -1,4 +1,4 @@
-temporalGrpcAddress: {{ TEMPORAL_ADDRESS | default("temporal-k8s:7233") }}
+temporalGrpcAddress: {{ TEMPORAL_ADDRESS }}
 port: {{ TEMPORAL_UI_PORT | default("8080") }}
 enableUi: {{ TEMPORAL_UI_ENABLED | default("true") }}
 defaultNamespace: {{ TEMPORAL_DEFAULT_NAMESPACE }}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,6 +37,7 @@ def deploy_temporal_stack(
     temporal_server_channel: str = TEMPORAL_CHANNEL,
     temporal_admin_channel: str = TEMPORAL_CHANNEL,
     temporal_ui_channel: str = TEMPORAL_CHANNEL,
+    integrate_host_info: bool = True,
 ):
     """Helper function to deploy the temporal stack.
 
@@ -46,10 +47,9 @@ def deploy_temporal_stack(
         temporal_server_channel: channel for temporal-k8s
         temporal_admin_channel: channel for temporal-admin-k8s
         temporal_ui_channel: channel for temporal-ui-k8s
-
-    Raises:
-        CLIError: Raised when `juju.integrate` returns a CLI error other than a
-            missing ``temporal-host-info`` endpoint on the server side.
+        integrate_host_info: whether to integrate the temporal-host-info relation.
+            Set to False when deploying temporal-ui-k8s from latest/edge (pre-dates
+            the relation); the test is responsible for integrating after refresh.
     """
     juju.model_config(
         values={
@@ -102,23 +102,7 @@ def deploy_temporal_stack(
     juju.integrate(f"{TEMPORAL_SERVER_JUJU_APP}:admin", "temporal-admin-k8s:admin")
 
     juju.integrate(f"{TEMPORAL_SERVER_JUJU_APP}:ui", "temporal-ui-k8s:ui")
-    if temporal_ui_channel.startswith("latest/"):
-        # Upgrade/refresh tests deploy the old published UI from latest/edge first.
-        # That revision pre-dates temporal-host-info, so skip if the server
-        # doesn't expose the endpoint yet.
-        try:
-            juju.integrate(
-                f"{TEMPORAL_SERVER_JUJU_APP}:temporal-host-info",
-                "temporal-ui-k8s:temporal-host-info",
-            )
-        except jubilant.CLIError as exc:
-            msg = str(exc).lower()
-            if "temporal-host-info" in msg and ("has no" in msg or "not found" in msg or "no relations found" in msg):
-                pass
-            else:
-                raise
-    else:
-        # All 1.23/edge+ revisions expose temporal-host-info; require it unconditionally.
+    if integrate_host_info:
         juju.integrate(
             f"{TEMPORAL_SERVER_JUJU_APP}:temporal-host-info",
             "temporal-ui-k8s:temporal-host-info",
@@ -129,8 +113,12 @@ def deploy_temporal_stack(
 
 @pytest.fixture(scope="module")
 def ui_latest_track(juju: jubilant.Juju):
-    """Deploy the temporal stack with temporal-ui from the latest/edge track."""
-    deploy_temporal_stack(juju, temporal_ui_channel="latest/edge")
+    """Deploy the temporal stack with temporal-ui from the latest/edge track.
+
+    temporal-host-info is not integrated here because the latest/edge revision
+    pre-dates that relation. The refresh test integrates it after refreshing to 1.23+.
+    """
+    deploy_temporal_stack(juju, temporal_ui_channel="latest/edge", integrate_host_info=False)
 
     return "temporal-ui-k8s"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,6 +97,7 @@ def deploy_temporal_stack(
     juju.integrate("temporal-k8s:admin", "temporal-admin-k8s:admin")
 
     juju.integrate("temporal-k8s:ui", "temporal-ui-k8s:ui")
+    juju.integrate("temporal-k8s:temporal-host-info", "temporal-ui-k8s:temporal-host-info")
 
     juju.wait(jubilant.all_active)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,7 +97,14 @@ def deploy_temporal_stack(
     juju.integrate("temporal-k8s:admin", "temporal-admin-k8s:admin")
 
     juju.integrate("temporal-k8s:ui", "temporal-ui-k8s:ui")
-    juju.integrate("temporal-k8s:temporal-host-info", "temporal-ui-k8s:temporal-host-info")
+    try:
+        juju.integrate("temporal-k8s:temporal-host-info", "temporal-ui-k8s:temporal-host-info")
+    except jubilant.CLIError as exc:
+        msg = str(exc).lower()
+        if "temporal-host-info" in msg and "has no" in msg:
+            juju.config("temporal-ui-k8s", {"server-name": "temporal-k8s"})
+        else:
+            raise
 
     juju.wait(jubilant.all_active)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -104,7 +104,7 @@ def deploy_temporal_stack(
     juju.integrate(f"{TEMPORAL_SERVER_JUJU_APP}:ui", "temporal-ui-k8s:ui")
     if temporal_ui_channel.startswith("latest/"):
         # Upgrade/refresh tests deploy the old published UI from latest/edge first.
-        # That revision pre-dates temporal-host-info, so silently skip if the server
+        # That revision pre-dates temporal-host-info, so skip if the server
         # doesn't expose the endpoint yet.
         try:
             juju.integrate(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,11 @@ import yaml
 POSTGRESQL_K8S_CHANNEL = "14/stable"
 TEMPORAL_CHANNEL = "1.23/edge"
 
+# CI bundle only: Juju application name for Temporal server. Matches historical in-cluster
+# gRPC target ``temporal-k8s:7233`` when published UI revisions lack ``temporal-host-info`` and
+# ``server-name`` (Juju cannot set unknown config keys).
+TEMPORAL_SERVER_JUJU_APP = "temporal-k8s"
+
 METADATA = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
 TEMPORAL_UI_IMAGE = METADATA["resources"]["temporal-ui-image"]["upstream-source"]
 
@@ -65,8 +70,8 @@ def deploy_temporal_stack(
     )
 
     juju.deploy(
-        charm="temporal-k8s",
-        app="temporal-k8s",
+        charm=TEMPORAL_SERVER_JUJU_APP,
+        app=TEMPORAL_SERVER_JUJU_APP,
         channel=temporal_server_channel,
         config={
             "num-history-shards": 1,
@@ -91,24 +96,40 @@ def deploy_temporal_stack(
     juju.wait(
         lambda status: (
             jubilant.all_active(status, "postgresql-k8s")
-            and jubilant.all_blocked(status, "temporal-k8s", "temporal-admin-k8s", "temporal-ui-k8s")
+            and jubilant.all_blocked(
+                status, TEMPORAL_SERVER_JUJU_APP, "temporal-admin-k8s", "temporal-ui-k8s"
+            )
         ),
     )
 
-    juju.integrate("temporal-k8s:db", "postgresql-k8s:database")
-    juju.integrate("temporal-k8s:visibility", "postgresql-k8s:database")
+    juju.integrate(f"{TEMPORAL_SERVER_JUJU_APP}:db", "postgresql-k8s:database")
+    juju.integrate(f"{TEMPORAL_SERVER_JUJU_APP}:visibility", "postgresql-k8s:database")
 
-    juju.integrate("temporal-k8s:admin", "temporal-admin-k8s:admin")
+    juju.integrate(f"{TEMPORAL_SERVER_JUJU_APP}:admin", "temporal-admin-k8s:admin")
 
-    juju.integrate("temporal-k8s:ui", "temporal-ui-k8s:ui")
+    juju.integrate(f"{TEMPORAL_SERVER_JUJU_APP}:ui", "temporal-ui-k8s:ui")
     try:
-        juju.integrate("temporal-k8s:temporal-host-info", "temporal-ui-k8s:temporal-host-info")
+        juju.integrate(
+            f"{TEMPORAL_SERVER_JUJU_APP}:temporal-host-info",
+            "temporal-ui-k8s:temporal-host-info",
+        )
     except jubilant.CLIError as exc:
         msg = str(exc).lower()
-        if "temporal-host-info" in msg and "has no" in msg:
-            juju.config("temporal-ui-k8s", {"server-name": "temporal-k8s"})
+        if "temporal-host-info" in msg and (
+            "has no" in msg or "not found" in msg or "no relations found" in msg
+        ):
+            try:
+                juju.config("temporal-ui-k8s", {"server-name": TEMPORAL_SERVER_JUJU_APP})
+            except jubilant.CLIError as cfg_exc:
+                cfg_msg = str(cfg_exc).lower()
+                if "unknown option" in cfg_msg and "server-name" in cfg_msg:
+                    # No host-info, no server-name key on this revision: rely on CI app name
+                    # TEMPORAL_SERVER_JUJU_APP (legacy implicit gRPC host for older published UI).
+                    pass
+                else:
+                    raise
         else:
-            raise jubilant.CLIError(str(exc)) from exc
+            raise
 
     juju.wait(jubilant.all_active)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,7 +97,6 @@ def deploy_temporal_stack(
     juju.integrate("temporal-k8s:admin", "temporal-admin-k8s:admin")
 
     juju.integrate("temporal-k8s:ui", "temporal-ui-k8s:ui")
-    juju.integrate("temporal-k8s:temporal-host-info", "temporal-ui-k8s:temporal-host-info")
 
     juju.wait(jubilant.all_active)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,10 +11,6 @@ import yaml
 
 POSTGRESQL_K8S_CHANNEL = "14/stable"
 TEMPORAL_CHANNEL = "1.23/edge"
-
-# CI bundle only: Juju application name for Temporal server. Matches historical in-cluster
-# gRPC target ``temporal-k8s:7233`` when published UI revisions lack ``temporal-host-info`` and
-# ``server-name`` (Juju cannot set unknown config keys).
 TEMPORAL_SERVER_JUJU_APP = "temporal-k8s"
 
 METADATA = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
@@ -53,7 +49,7 @@ def deploy_temporal_stack(
 
     Raises:
         CLIError: Raised when `juju.integrate` returns a CLI error other than a
-            missing `temporal-host-info` endpoint.
+            missing ``temporal-host-info`` endpoint on the server side.
     """
     juju.model_config(
         values={
@@ -96,9 +92,7 @@ def deploy_temporal_stack(
     juju.wait(
         lambda status: (
             jubilant.all_active(status, "postgresql-k8s")
-            and jubilant.all_blocked(
-                status, TEMPORAL_SERVER_JUJU_APP, "temporal-admin-k8s", "temporal-ui-k8s"
-            )
+            and jubilant.all_blocked(status, TEMPORAL_SERVER_JUJU_APP, "temporal-admin-k8s", "temporal-ui-k8s")
         ),
     )
 
@@ -108,28 +102,27 @@ def deploy_temporal_stack(
     juju.integrate(f"{TEMPORAL_SERVER_JUJU_APP}:admin", "temporal-admin-k8s:admin")
 
     juju.integrate(f"{TEMPORAL_SERVER_JUJU_APP}:ui", "temporal-ui-k8s:ui")
-    try:
+    if temporal_ui_channel.startswith("latest/"):
+        # Upgrade/refresh tests deploy the old published UI from latest/edge first.
+        # That revision pre-dates temporal-host-info, so silently skip if the server
+        # doesn't expose the endpoint yet.
+        try:
+            juju.integrate(
+                f"{TEMPORAL_SERVER_JUJU_APP}:temporal-host-info",
+                "temporal-ui-k8s:temporal-host-info",
+            )
+        except jubilant.CLIError as exc:
+            msg = str(exc).lower()
+            if "temporal-host-info" in msg and ("has no" in msg or "not found" in msg or "no relations found" in msg):
+                pass
+            else:
+                raise
+    else:
+        # All 1.23/edge+ revisions expose temporal-host-info; require it unconditionally.
         juju.integrate(
             f"{TEMPORAL_SERVER_JUJU_APP}:temporal-host-info",
             "temporal-ui-k8s:temporal-host-info",
         )
-    except jubilant.CLIError as exc:
-        msg = str(exc).lower()
-        if "temporal-host-info" in msg and (
-            "has no" in msg or "not found" in msg or "no relations found" in msg
-        ):
-            try:
-                juju.config("temporal-ui-k8s", {"server-name": TEMPORAL_SERVER_JUJU_APP})
-            except jubilant.CLIError as cfg_exc:
-                cfg_msg = str(cfg_exc).lower()
-                if "unknown option" in cfg_msg and "server-name" in cfg_msg:
-                    # No host-info, no server-name key on this revision: rely on CI app name
-                    # TEMPORAL_SERVER_JUJU_APP (legacy implicit gRPC host for older published UI).
-                    pass
-                else:
-                    raise
-        else:
-            raise
 
     juju.wait(jubilant.all_active)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,6 +45,10 @@ def deploy_temporal_stack(
         temporal_server_channel: channel for temporal-k8s
         temporal_admin_channel: channel for temporal-admin-k8s
         temporal_ui_channel: channel for temporal-ui-k8s
+
+    Raises:
+        CLIError: Raised when `juju.integrate` returns a CLI error other than a
+            missing `temporal-host-info` endpoint.
     """
     juju.model_config(
         values={
@@ -104,7 +108,7 @@ def deploy_temporal_stack(
         if "temporal-host-info" in msg and "has no" in msg:
             juju.config("temporal-ui-k8s", {"server-name": "temporal-k8s"})
         else:
-            raise
+            raise jubilant.CLIError(str(exc)) from exc
 
     juju.wait(jubilant.all_active)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -72,7 +72,7 @@ def deploy_temporal_stack(
         config={
             "num-history-shards": 1,
         },
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
     )
 
     juju.deploy(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -8,46 +8,9 @@
 import logging
 import socket
 
-import juju.errors
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
-
-
-def _temporal_host_info_endpoint_missing(exc: BaseException) -> bool:
-    msg = str(exc).lower()
-    return "temporal-host-info" in msg and "has no" in msg
-
-
-async def integrate_temporal_host_info_or_set_server_name(
-    ops_test: OpsTest,
-    *,
-    ui_app: str,
-    temporal_server_app: str,
-) -> bool:
-    """Integrate temporal-host-info if temporal-k8s exposes it; else set deprecated server-name.
-
-    Published ``temporal-k8s`` revisions may not include the endpoint yet; tests still need UI active.
-
-    Returns:
-        True if the relation was integrated, False if server-name fallback was used.
-    """
-    try:
-        await ops_test.model.integrate(
-            f"{ui_app}:temporal-host-info",
-            f"{temporal_server_app}:temporal-host-info",
-        )
-    except juju.errors.JujuAPIError as exc:
-        if not _temporal_host_info_endpoint_missing(exc):
-            raise
-        logger.warning(
-            "%s has no temporal-host-info; setting UI server-name=%s",
-            temporal_server_app,
-            temporal_server_app,
-        )
-        await ops_test.model.applications[ui_app].set_config({"server-name": temporal_server_app})
-        return False
-    return True
 
 
 def gen_patch_getaddrinfo(host: str, resolve_to: str):  # noqa

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -5,9 +5,49 @@
 
 """Temporal UI charm integration test helpers."""
 
+import logging
 import socket
 
+import juju.errors
 from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+def _temporal_host_info_endpoint_missing(exc: BaseException) -> bool:
+    msg = str(exc).lower()
+    return "temporal-host-info" in msg and "has no" in msg
+
+
+async def integrate_temporal_host_info_or_set_server_name(
+    ops_test: OpsTest,
+    *,
+    ui_app: str,
+    temporal_server_app: str,
+) -> bool:
+    """Integrate temporal-host-info if temporal-k8s exposes it; else set deprecated server-name.
+
+    Published ``temporal-k8s`` revisions may not include the endpoint yet; tests still need UI active.
+
+    Returns:
+        True if the relation was integrated, False if server-name fallback was used.
+    """
+    try:
+        await ops_test.model.integrate(
+            f"{ui_app}:temporal-host-info",
+            f"{temporal_server_app}:temporal-host-info",
+        )
+    except juju.errors.JujuAPIError as exc:
+        if not _temporal_host_info_endpoint_missing(exc):
+            raise
+        logger.warning(
+            "%s has no temporal-host-info; setting UI server-name=%s",
+            temporal_server_app,
+            temporal_server_app,
+        )
+        await ops_test.model.applications[ui_app].set_config({"server-name": temporal_server_app})
+        return False
+    return True
 
 
 def gen_patch_getaddrinfo(host: str, resolve_to: str):  # noqa

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -85,6 +85,7 @@ async def deploy(ops_test: OpsTest):
         )
 
         await ops_test.model.integrate(f"{APP_NAME}:ui", f"{APP_NAME_SERVER}:ui")
+        await ops_test.model.integrate(f"{APP_NAME}:temporal-host-info", f"{APP_NAME_SERVER}:temporal-host-info")
 
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],
@@ -174,7 +175,8 @@ class TestDeployment:
         await scale(ops_test, app=APP_NAME, units=2)
 
     async def test_host_info_relation(self, ops_test: OpsTest):
-        """Test that host-info relation provides correct info."""
+        """Test that host-info relation takes precedence over deprecated fallback config."""
+        await ops_test.model.applications[APP_NAME].set_config({"server-name": "deprecated-host"})
         status = await ops_test.model.get_status()  # noqa: F821
         await ops_test.model.integrate(f"{APP_NAME}:temporal-host-info", f"{APP_NAME_SERVER}:temporal-host-info")
         async with ops_test.fast_forward():
@@ -192,8 +194,9 @@ class TestDeployment:
         charm_config = yaml.safe_load(result.stdout)
         assert charm_config["temporalGrpcAddress"] == f"{server_address}:7233"
 
-    async def test_host_info_relation_removed_falls_back_to_default(self, ops_test: OpsTest):
-        """Test that removing host-info relation falls back to default server address."""
+    async def test_host_info_relation_removed_falls_back_to_config(self, ops_test: OpsTest):
+        """Test that removing host-info relation falls back to deprecated config value."""
+        await ops_test.model.applications[APP_NAME].set_config({"server-name": "fallback-host"})
         await ops_test.juju(
             "remove-relation",
             f"{APP_NAME}:temporal-host-info",
@@ -210,4 +213,4 @@ class TestDeployment:
         unit = ops_test.model.applications[APP_NAME].units[0]
         result = await unit.run("cat /home/ui-server/config/charm.yaml")
         charm_config = yaml.safe_load(result.stdout)
-        assert charm_config["temporalGrpcAddress"] == "temporal-k8s:7233"
+        assert charm_config["temporalGrpcAddress"] == "fallback-host:7233"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -15,11 +15,7 @@ import pytest_asyncio
 import requests
 import yaml
 from conftest import POSTGRESQL_K8S_CHANNEL, TEMPORAL_CHANNEL
-from helpers import (
-    gen_patch_getaddrinfo,
-    integrate_temporal_host_info_or_set_server_name,
-    scale,
-)
+from helpers import gen_patch_getaddrinfo, scale
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -32,14 +28,10 @@ APP_NAME_ADMIN = "temporal-admin-k8s"
 
 NGINX_INGRESS_INTEGRATOR_CHANNEL = "latest/edge"
 
-_TEMPORAL_SERVER_SUPPORTS_HOST_INFO: bool | None = None
-
 
 @pytest_asyncio.fixture(name="deploy", scope="module")
 async def deploy(ops_test: OpsTest):
     """The app is up and running."""
-    global _TEMPORAL_SERVER_SUPPORTS_HOST_INFO
-
     # Deploy temporal server, temporal admin and postgresql charms.
     await asyncio.gather(
         ops_test.model.deploy(APP_NAME_SERVER, channel=TEMPORAL_CHANNEL, config={"num-history-shards": 1}),
@@ -93,9 +85,7 @@ async def deploy(ops_test: OpsTest):
         )
 
         await ops_test.model.integrate(f"{APP_NAME}:ui", f"{APP_NAME_SERVER}:ui")
-        _TEMPORAL_SERVER_SUPPORTS_HOST_INFO = await integrate_temporal_host_info_or_set_server_name(
-            ops_test, ui_app=APP_NAME, temporal_server_app=APP_NAME_SERVER
-        )
+        await ops_test.model.integrate(f"{APP_NAME}:temporal-host-info", f"{APP_NAME_SERVER}:temporal-host-info")
 
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],
@@ -185,20 +175,8 @@ class TestDeployment:
         await scale(ops_test, app=APP_NAME, units=2)
 
     async def test_host_info_relation(self, ops_test: OpsTest):
-        """Test that host-info relation takes precedence over deprecated fallback config."""
-        if _TEMPORAL_SERVER_SUPPORTS_HOST_INFO is not True:
-            pytest.skip("temporal-k8s on this channel has no temporal-host-info relation")
-        await ops_test.model.applications[APP_NAME].set_config({"server-name": "deprecated-host"})
+        """Test that the server address from the host-info relation is used in charm config."""
         status = await ops_test.model.get_status()  # noqa: F821
-        await ops_test.model.integrate(f"{APP_NAME}:temporal-host-info", f"{APP_NAME_SERVER}:temporal-host-info")
-        async with ops_test.fast_forward():
-            await ops_test.model.wait_for_idle(
-                apps=[APP_NAME, APP_NAME_SERVER],
-                status="active",
-                raise_on_blocked=False,
-                timeout=600,
-            )
-
         server_address = status["applications"][APP_NAME_SERVER]["units"][f"{APP_NAME_SERVER}/0"]["address"]
 
         unit = ops_test.model.applications[APP_NAME].units[0]
@@ -206,11 +184,8 @@ class TestDeployment:
         charm_config = yaml.safe_load(result.stdout)
         assert charm_config["temporalGrpcAddress"] == f"{server_address}:7233"
 
-    async def test_host_info_relation_removed_falls_back_to_config(self, ops_test: OpsTest):
-        """Test that removing host-info relation falls back to deprecated config value."""
-        if _TEMPORAL_SERVER_SUPPORTS_HOST_INFO is not True:
-            pytest.skip("temporal-k8s on this channel has no temporal-host-info relation")
-        await ops_test.model.applications[APP_NAME].set_config({"server-name": "fallback-host"})
+    async def test_host_info_relation_removed_causes_blocked(self, ops_test: OpsTest):
+        """Test that removing the host-info relation causes the charm to go blocked."""
         await ops_test.juju(
             "remove-relation",
             f"{APP_NAME}:temporal-host-info",
@@ -218,13 +193,20 @@ class TestDeployment:
         )
         async with ops_test.fast_forward():
             await ops_test.model.wait_for_idle(
-                apps=[APP_NAME, APP_NAME_SERVER],
-                status="active",
+                apps=[APP_NAME],
+                status="blocked",
                 raise_on_blocked=False,
-                timeout=600,
+                timeout=300,
             )
 
-        unit = ops_test.model.applications[APP_NAME].units[0]
-        result = await unit.run("cat /home/ui-server/config/charm.yaml")
-        charm_config = yaml.safe_load(result.stdout)
-        assert charm_config["temporalGrpcAddress"] == "fallback-host:7233"
+        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "blocked"
+
+        # Re-integrate so subsequent tests still have an active charm.
+        await ops_test.model.integrate(f"{APP_NAME}:temporal-host-info", f"{APP_NAME_SERVER}:temporal-host-info")
+        async with ops_test.fast_forward():
+            await ops_test.model.wait_for_idle(
+                apps=[APP_NAME],
+                status="active",
+                raise_on_blocked=False,
+                timeout=300,
+            )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -15,7 +15,11 @@ import pytest_asyncio
 import requests
 import yaml
 from conftest import POSTGRESQL_K8S_CHANNEL, TEMPORAL_CHANNEL
-from helpers import gen_patch_getaddrinfo, integrate_temporal_host_info_or_set_server_name, scale
+from helpers import (
+    gen_patch_getaddrinfo,
+    integrate_temporal_host_info_or_set_server_name,
+    scale,
+)
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -15,7 +15,7 @@ import pytest_asyncio
 import requests
 import yaml
 from conftest import POSTGRESQL_K8S_CHANNEL, TEMPORAL_CHANNEL
-from helpers import gen_patch_getaddrinfo, scale
+from helpers import gen_patch_getaddrinfo, integrate_temporal_host_info_or_set_server_name, scale
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -28,10 +28,14 @@ APP_NAME_ADMIN = "temporal-admin-k8s"
 
 NGINX_INGRESS_INTEGRATOR_CHANNEL = "latest/edge"
 
+_TEMPORAL_SERVER_SUPPORTS_HOST_INFO: bool | None = None
+
 
 @pytest_asyncio.fixture(name="deploy", scope="module")
 async def deploy(ops_test: OpsTest):
     """The app is up and running."""
+    global _TEMPORAL_SERVER_SUPPORTS_HOST_INFO
+
     # Deploy temporal server, temporal admin and postgresql charms.
     await asyncio.gather(
         ops_test.model.deploy(APP_NAME_SERVER, channel=TEMPORAL_CHANNEL, config={"num-history-shards": 1}),
@@ -85,7 +89,9 @@ async def deploy(ops_test: OpsTest):
         )
 
         await ops_test.model.integrate(f"{APP_NAME}:ui", f"{APP_NAME_SERVER}:ui")
-        await ops_test.model.integrate(f"{APP_NAME}:temporal-host-info", f"{APP_NAME_SERVER}:temporal-host-info")
+        _TEMPORAL_SERVER_SUPPORTS_HOST_INFO = await integrate_temporal_host_info_or_set_server_name(
+            ops_test, ui_app=APP_NAME, temporal_server_app=APP_NAME_SERVER
+        )
 
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],
@@ -176,6 +182,8 @@ class TestDeployment:
 
     async def test_host_info_relation(self, ops_test: OpsTest):
         """Test that host-info relation takes precedence over deprecated fallback config."""
+        if _TEMPORAL_SERVER_SUPPORTS_HOST_INFO is not True:
+            pytest.skip("temporal-k8s on this channel has no temporal-host-info relation")
         await ops_test.model.applications[APP_NAME].set_config({"server-name": "deprecated-host"})
         status = await ops_test.model.get_status()  # noqa: F821
         await ops_test.model.integrate(f"{APP_NAME}:temporal-host-info", f"{APP_NAME_SERVER}:temporal-host-info")
@@ -196,6 +204,8 @@ class TestDeployment:
 
     async def test_host_info_relation_removed_falls_back_to_config(self, ops_test: OpsTest):
         """Test that removing host-info relation falls back to deprecated config value."""
+        if _TEMPORAL_SERVER_SUPPORTS_HOST_INFO is not True:
+            pytest.skip("temporal-k8s on this channel has no temporal-host-info relation")
         await ops_test.model.applications[APP_NAME].set_config({"server-name": "fallback-host"})
         await ops_test.juju(
             "remove-relation",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -180,8 +180,11 @@ class TestDeployment:
         server_address = status["applications"][APP_NAME_SERVER]["units"][f"{APP_NAME_SERVER}/0"]["address"]
 
         unit = ops_test.model.applications[APP_NAME].units[0]
-        result = await unit.run("cat /home/ui-server/config/charm.yaml")
-        charm_config = yaml.safe_load(result.stdout)
+        action = await unit.run("cat /home/ui-server/config/charm.yaml")
+        await action.wait()
+        stdout = action.results.get("stdout") or action.results.get("Stdout")
+        assert stdout is not None, action.results
+        charm_config = yaml.safe_load(stdout)
         assert charm_config["temporalGrpcAddress"] == f"{server_address}:7233"
 
     async def test_host_info_relation_removed_causes_blocked(self, ops_test: OpsTest):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -38,7 +38,11 @@ async def deploy(ops_test: OpsTest):
         ops_test.model.deploy(APP_NAME_ADMIN, channel=TEMPORAL_CHANNEL),
         ops_test.model.deploy("postgresql-k8s", channel=POSTGRESQL_K8S_CHANNEL, trust=True),
         ops_test.model.deploy(
-            "nginx-ingress-integrator", channel=NGINX_INGRESS_INTEGRATOR_CHANNEL, revision=100, trust=True, config={"ingress-class": "nginx"},
+            "nginx-ingress-integrator",
+            channel=NGINX_INGRESS_INTEGRATOR_CHANNEL,
+            revision=100,
+            trust=True,
+            config={"ingress-class": "nginx"},
         ),
     )
 
@@ -130,12 +134,17 @@ class TestDeployment:
                 timeout=1200,
             )
             exit_code, stdout, stderr = await ops_test.run(
-            "kubectl", "-n", "ingress-nginx",
-            "get", "svc", "ingress-nginx-controller",
-            "-o", "jsonpath={.status.loadBalancer.ingress[0].ip}"
+                "kubectl",
+                "-n",
+                "ingress-nginx",
+                "get",
+                "svc",
+                "ingress-nginx-controller",
+                "-o",
+                "jsonpath={.status.loadBalancer.ingress[0].ip}",
             )
             ingress_ip = stdout.strip()
-            
+
             with unittest.mock.patch.multiple(socket, getaddrinfo=gen_patch_getaddrinfo(new_hostname, ingress_ip)):
                 response = requests.get(
                     f"https://{ingress_ip}",
@@ -163,3 +172,22 @@ class TestDeployment:
     async def test_scaling_up(self, ops_test: OpsTest):
         """Scale Temporal worker charm up to 2 units."""
         await scale(ops_test, app=APP_NAME, units=2)
+
+    async def test_host_info_relation(self, ops_test: OpsTest):
+        """Test that host-info relation provides correct info."""
+        status = await ops_test.model.get_status()  # noqa: F821
+        await ops_test.model.integrate(f"{APP_NAME}:temporal-host-info", f"{APP_NAME_SERVER}:temporal-host-info")
+        async with ops_test.fast_forward():
+            await ops_test.model.wait_for_idle(
+                apps=[APP_NAME, APP_NAME_SERVER],
+                status="active",
+                raise_on_blocked=False,
+                timeout=600,
+            )
+
+        server_address = status["applications"][APP_NAME_SERVER]["units"][f"{APP_NAME_SERVER}/0"]["address"]
+
+        unit = ops_test.model.applications[APP_NAME].units[0]
+        result = await unit.run("cat /home/ui-server/config/charm.yaml")
+        charm_config = yaml.safe_load(result.stdout)
+        assert charm_config["temporalGrpcAddress"] == f"{server_address}:7233"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -33,7 +33,7 @@ NGINX_INGRESS_INTEGRATOR_CHANNEL = "latest/edge"
 async def deploy(ops_test: OpsTest):
     """The app is up and running."""
     # Deploy temporal server, temporal admin and postgresql charms.
-    asyncio.gather(
+    await asyncio.gather(
         ops_test.model.deploy(APP_NAME_SERVER, channel=TEMPORAL_CHANNEL, config={"num-history-shards": 1}),
         ops_test.model.deploy(APP_NAME_ADMIN, channel=TEMPORAL_CHANNEL),
         ops_test.model.deploy("postgresql-k8s", channel=POSTGRESQL_K8S_CHANNEL, trust=True),

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -179,11 +179,13 @@ class TestDeployment:
         status = await ops_test.model.get_status()  # noqa: F821
         server_address = status["applications"][APP_NAME_SERVER]["units"][f"{APP_NAME_SERVER}/0"]["address"]
 
-        unit = ops_test.model.applications[APP_NAME].units[0]
-        action = await unit.run("cat /home/ui-server/config/charm.yaml")
-        await action.wait()
-        stdout = action.results.get("stdout") or action.results.get("Stdout")
-        assert stdout is not None, action.results
+        _, stdout, _ = await ops_test.juju(
+            "ssh",
+            "--container",
+            "temporal-ui",
+            f"{APP_NAME}/0",
+            "cat /home/ui-server/config/charm.yaml",
+        )
         charm_config = yaml.safe_load(stdout)
         assert charm_config["temporalGrpcAddress"] == f"{server_address}:7233"
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -191,3 +191,23 @@ class TestDeployment:
         result = await unit.run("cat /home/ui-server/config/charm.yaml")
         charm_config = yaml.safe_load(result.stdout)
         assert charm_config["temporalGrpcAddress"] == f"{server_address}:7233"
+
+    async def test_host_info_relation_removed_falls_back_to_default(self, ops_test: OpsTest):
+        """Test that removing host-info relation falls back to default server address."""
+        await ops_test.juju(
+            "remove-relation",
+            f"{APP_NAME}:temporal-host-info",
+            f"{APP_NAME_SERVER}:temporal-host-info",
+        )
+        async with ops_test.fast_forward():
+            await ops_test.model.wait_for_idle(
+                apps=[APP_NAME, APP_NAME_SERVER],
+                status="active",
+                raise_on_blocked=False,
+                timeout=600,
+            )
+
+        unit = ops_test.model.applications[APP_NAME].units[0]
+        result = await unit.run("cat /home/ui-server/config/charm.yaml")
+        charm_config = yaml.safe_load(result.stdout)
+        assert charm_config["temporalGrpcAddress"] == "temporal-k8s:7233"

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -6,6 +6,7 @@
 import logging
 
 import jubilant
+from conftest import TEMPORAL_SERVER_JUJU_APP
 
 logger = logging.getLogger(__name__)
 
@@ -17,4 +18,10 @@ def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, ui_latest_track, charm
         path=charm_path,
         resources=charm_resources,
     )
+
+    juju.integrate(
+        f"{TEMPORAL_SERVER_JUJU_APP}:temporal-host-info",
+        f"{ui_latest_track}:temporal-host-info",
+    )
+
     juju.wait(jubilant.all_active, error=jubilant.any_error)

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -19,6 +19,11 @@ def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, ui_latest_track, charm
         resources=charm_resources,
     )
 
+    # Wait for the refreshed charm to settle: it requires temporal-host-info and will
+    # be blocked until the relation is established. This ensures upgrade hooks complete
+    # before we trigger temporal-k8s to process the new relation-joined hook.
+    juju.wait(lambda status: jubilant.all_blocked(status, ui_latest_track))
+
     juju.integrate(
         f"{TEMPORAL_SERVER_JUJU_APP}:temporal-host-info",
         f"{ui_latest_track}:temporal-host-info",

--- a/tests/integration/test_traefik_ingress.py
+++ b/tests/integration/test_traefik_ingress.py
@@ -34,7 +34,7 @@ TRAEFIK_K8S_TRUST = True
 async def deploy(ops_test: OpsTest):
     """The app is up and running."""
     # Deploy temporal server, temporal admin, traefik-k8s, and postgresql charms.
-    asyncio.gather(
+    await asyncio.gather(
         ops_test.model.deploy(TEMPORAL_SERVER, channel=TEMPORAL_CHANNEL, config={"num-history-shards": 1}),
         ops_test.model.deploy(TEMPORAL_ADMIN, channel=TEMPORAL_CHANNEL),
         ops_test.model.deploy(POSTGRESQL_K8S, channel=POSTGRESQL_K8S_CHANNEL, trust=POSTGRESQL_K8S_TRUST),
@@ -52,6 +52,7 @@ async def deploy(ops_test: OpsTest):
         await ops_test.model.integrate(f"{TEMPORAL_SERVER}:visibility", f"{POSTGRESQL_K8S}:database")
         await ops_test.model.integrate(f"{TEMPORAL_SERVER}:admin", f"{TEMPORAL_ADMIN}:admin")
         await ops_test.model.integrate(f"{APP_NAME}:ui", f"{TEMPORAL_SERVER}:ui")
+        await ops_test.model.integrate(f"{APP_NAME}:temporal-host-info", f"{TEMPORAL_SERVER}:temporal-host-info")
         await ops_test.model.integrate(f"{APP_NAME}:ingress", f"{TRAEFIK_K8S}:ingress")
 
         await ops_test.model.wait_for_idle(

--- a/tests/integration/test_traefik_ingress.py
+++ b/tests/integration/test_traefik_ingress.py
@@ -14,6 +14,7 @@ import pytest_asyncio
 import requests
 import yaml
 from conftest import POSTGRESQL_K8S_CHANNEL, TEMPORAL_CHANNEL
+from helpers import integrate_temporal_host_info_or_set_server_name
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -52,7 +53,9 @@ async def deploy(ops_test: OpsTest):
         await ops_test.model.integrate(f"{TEMPORAL_SERVER}:visibility", f"{POSTGRESQL_K8S}:database")
         await ops_test.model.integrate(f"{TEMPORAL_SERVER}:admin", f"{TEMPORAL_ADMIN}:admin")
         await ops_test.model.integrate(f"{APP_NAME}:ui", f"{TEMPORAL_SERVER}:ui")
-        await ops_test.model.integrate(f"{APP_NAME}:temporal-host-info", f"{TEMPORAL_SERVER}:temporal-host-info")
+        await integrate_temporal_host_info_or_set_server_name(
+            ops_test, ui_app=APP_NAME, temporal_server_app=TEMPORAL_SERVER
+        )
         await ops_test.model.integrate(f"{APP_NAME}:ingress", f"{TRAEFIK_K8S}:ingress")
 
         await ops_test.model.wait_for_idle(

--- a/tests/integration/test_traefik_ingress.py
+++ b/tests/integration/test_traefik_ingress.py
@@ -14,7 +14,6 @@ import pytest_asyncio
 import requests
 import yaml
 from conftest import POSTGRESQL_K8S_CHANNEL, TEMPORAL_CHANNEL
-from helpers import integrate_temporal_host_info_or_set_server_name
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -53,9 +52,7 @@ async def deploy(ops_test: OpsTest):
         await ops_test.model.integrate(f"{TEMPORAL_SERVER}:visibility", f"{POSTGRESQL_K8S}:database")
         await ops_test.model.integrate(f"{TEMPORAL_SERVER}:admin", f"{TEMPORAL_ADMIN}:admin")
         await ops_test.model.integrate(f"{APP_NAME}:ui", f"{TEMPORAL_SERVER}:ui")
-        await integrate_temporal_host_info_or_set_server_name(
-            ops_test, ui_app=APP_NAME, temporal_server_app=TEMPORAL_SERVER
-        )
+        await ops_test.model.integrate(f"{APP_NAME}:temporal-host-info", f"{TEMPORAL_SERVER}:temporal-host-info")
         await ops_test.model.integrate(f"{APP_NAME}:ingress", f"{TRAEFIK_K8S}:ingress")
 
         await ops_test.model.wait_for_idle(

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -120,6 +120,15 @@ def ui_relation():
 
 
 @pytest.fixture(scope="function")
+def host_info_relation():
+    """Provider app data for temporal-host-info (requirer reads remote app databag)."""
+    return ops.testing.Relation(
+        "temporal-host-info",
+        remote_app_data={"host": "10.0.0.1", "port": "7233"},
+    )
+
+
+@pytest.fixture(scope="function")
 def nginx_relation():
     return ops.testing.Relation("nginx-route")
 
@@ -130,8 +139,8 @@ def traefik_relation():
 
 
 @pytest.fixture
-def all_required_relations(peer_relation, ui_relation):
-    return [peer_relation, ui_relation]
+def all_required_relations(peer_relation, ui_relation, host_info_relation):
+    return [peer_relation, ui_relation, host_info_relation]
 
 
 @pytest.fixture

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -123,6 +123,7 @@ def test_ready(context, state, temporal_ui_container, temporal_ui_container_init
                 "environment": {
                     "LOG_LEVEL": "info",
                     "TEMPORAL_UI_PORT": 8080,
+                    "TEMPORAL_ADDRESS": "10.0.0.1:7233",
                     "TEMPORAL_DEFAULT_NAMESPACE": "default",
                     "TEMPORAL_AUTH_ENABLED": False,
                     "TEMPORAL_WORKFLOW_CANCEL_DISABLED": False,
@@ -176,6 +177,7 @@ def test_auth(
                     "environment": {
                         "LOG_LEVEL": "info",
                         "TEMPORAL_UI_PORT": 8080,
+                        "TEMPORAL_ADDRESS": "10.0.0.1:7233",
                         "TEMPORAL_DEFAULT_NAMESPACE": "default",
                         "TEMPORAL_AUTH_ENABLED": True,
                         "TEMPORAL_AUTH_PROVIDER_URL": "some-provider-url",

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 UI_PORT = "8080"
 
 
-
 def test_smoke(context, state):
     context.run(context.on.start(), state)
 
@@ -323,5 +322,3 @@ def test_traefik_ingress_ready(
 
     assert state_out.unit_status == ops.MaintenanceStatus("replanning application")
     assert state_out.get_container("temporal-ui").service_statuses["temporal-ui"] == ops.pebble.ServiceStatus.ACTIVE
-
-

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -28,6 +28,17 @@ def test_blocked_by_temporal_server(context, state, temporal_ui_container, all_r
     assert state_out.unit_status == ops.BlockedStatus("ui:temporal relation: not available")
 
 
+def test_blocked_when_host_info_absent(
+    context, state, temporal_ui_container, all_required_relations, host_info_relation
+):
+    all_required_relations.remove(host_info_relation)
+    state = dataclasses.replace(state, relations=all_required_relations)
+
+    state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
+
+    assert state_out.unit_status == ops.BlockedStatus("temporal-host-info relation not established")
+
+
 def test_blocked_by_peer_relation_not_ready(
     context, state, temporal_ui_container, all_required_relations, peer_relation
 ):


### PR DESCRIPTION
## Description
Adds the `temporal-host-info` relation with the temporal-k8s charm. Depends on https://github.com/canonical/temporal-k8s-operator/pull/114

---
## Testing instructions
1. Build charm
2. Verify the UI can still see the status of the Temporal server without relation
3. Integrate with `temporal-k8s` over `temporal-host-info` interface
4. Verify the UI can still see the status of the Temporal server without relation

---
## Checklist (all that apply)
- [X] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
