### PR TITLE
[WF-274] Skip TiCS workflow on fork PRs

### DIFF
--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
     tics:
+        # Only run if we have access to secrets.
+        if: github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name
         name: TiCs
         uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
         with: 

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -149,7 +149,7 @@ def test_ready(context, state, temporal_ui_container, temporal_ui_container_init
                     "TEMPORAL_WORKFLOW_TERMINATE_DISABLED": False,
                     "TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS": False,
                     "TEMPORAL_CODEC_ENDPOINT": "",
-                    "TEMPORAL_CODEC_PASS_ACCESS_TOKEN": False,
+                    "TEMPORAL_CODEC_PASS_ACCESS_TOKEN": False,  # nosec B105
                     "TEMPORAL_BATCH_ACTIONS_DISABLED": False,
                 },
                 "on-check-failure": {"up": "ignore"},
@@ -198,7 +198,7 @@ def test_auth(
                         "TEMPORAL_AUTH_ENABLED": True,
                         "TEMPORAL_AUTH_PROVIDER_URL": "some-provider-url",
                         "TEMPORAL_AUTH_CLIENT_ID": "some-client-id",
-                        "TEMPORAL_AUTH_CLIENT_SECRET": "some-client-secret",
+                        "TEMPORAL_AUTH_CLIENT_SECRET": "some-client-secret",  # nosec B105
                         "TEMPORAL_AUTH_SCOPES": "[openid,profile,email]",
                         "TEMPORAL_AUTH_CALLBACK_URL": f"https://{external_hostname}/auth/sso/callback",
                         "TEMPORAL_WORKFLOW_CANCEL_DISABLED": False,
@@ -207,7 +207,7 @@ def test_auth(
                         "TEMPORAL_WORKFLOW_TERMINATE_DISABLED": False,
                         "TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS": False,
                         "TEMPORAL_CODEC_ENDPOINT": "",
-                        "TEMPORAL_CODEC_PASS_ACCESS_TOKEN": False,
+                        "TEMPORAL_CODEC_PASS_ACCESS_TOKEN": False,  # nosec B105
                         "TEMPORAL_BATCH_ACTIONS_DISABLED": False,
                     },
                     "on-check-failure": {"up": "ignore"},


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Skips the Tiobe TiCS Analysis workflow on PRs from forks so it doesn’t fail as fork PRs can’t use repo secrets.

# Changes
- Add `if` condition on the `tics` job: run only when `event_name != 'pull_request'` or when the PR head repo equals the workflow repo.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

Closes canonical/temporal-k8s-operator#124
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
