### PR TITLE
[WF-307] add Traefik ingress integration for the web UI

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,7 +14,7 @@ jobs:
       channel: 1.33-classic/stable
       juju-channel: 3.6/stable
       charmcraft-channel: latest/candidate
-      modules: '["test_charm.py", "test_refresh.py"]'
+      modules: '["test_charm.py", "test_refresh.py", "test_traefik_ingress.py"]'
       pre-run-script: .github/scripts/init-pytest-ui.sh
       self-hosted-runner: true
       self-hosted-runner-label: large

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,3 +7,5 @@ jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
+    with:
+      require-check-lib: true

--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ for usage instructions.
 This charm is still in active development. Please see the
 [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm
 following best practice guidelines, and `CONTRIBUTING.md` for developer guidance.
+
+<!-- Test PR: verify Tiobe TiCS is skipped for fork PRs -->

--- a/README.md
+++ b/README.md
@@ -29,5 +29,3 @@ for usage instructions.
 This charm is still in active development. Please see the
 [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm
 following best practice guidelines, and `CONTRIBUTING.md` for developer guidance.
-
-<!-- Test PR: verify Tiobe TiCS is skipped for fork PRs -->

--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -1,0 +1,951 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+r"""# Interface Library for ingress.
+
+This library wraps relation endpoints using the `ingress` interface
+and provides a Python API for both requesting and providing per-application
+ingress, with load-balancing occurring across all units.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.traefik_k8s.v2.ingress
+```
+
+In the `metadata.yaml` of the charm, add the following:
+
+```yaml
+requires:
+    ingress:
+        interface: ingress
+        limit: 1
+```
+
+Then, to initialise the library:
+
+```python
+from charms.traefik_k8s.v2.ingress import (IngressPerAppRequirer,
+  IngressPerAppReadyEvent, IngressPerAppRevokedEvent)
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.ingress = IngressPerAppRequirer(self, port=80)
+    # The following event is triggered when the ingress URL to be used
+    # by this deployment of the `SomeCharm` is ready (or changes).
+    self.framework.observe(
+        self.ingress.on.ready, self._on_ingress_ready
+    )
+    self.framework.observe(
+        self.ingress.on.revoked, self._on_ingress_revoked
+    )
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
+        logger.info("This app's ingress URL: %s", event.url)
+
+    def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent):
+        logger.info("This app no longer has ingress")
+"""
+
+import ipaddress
+import json
+import logging
+import socket
+import typing
+from dataclasses import dataclass
+from functools import partial
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
+
+import pydantic
+from ops import EventBase
+from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
+from ops.framework import EventSource, Object, ObjectEvents, StoredState
+from ops.model import ModelError, Relation, Unit
+from pydantic import AnyHttpUrl, BaseModel, Field
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e6de2a5cd5b34422a204668f3b8f90d2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 2
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 19
+
+PYDEPS = ["pydantic"]
+
+DEFAULT_RELATION_NAME = "ingress"
+RELATION_INTERFACE = "ingress"
+
+log = logging.getLogger(__name__)
+BUILTIN_JUJU_KEYS = {"ingress-address", "private-address", "egress-subnets"}
+
+PYDANTIC_IS_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
+if PYDANTIC_IS_V1:  # noqa
+    from pydantic import validator
+
+    input_validator = partial(validator, pre=True)
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        class Config:
+            """Pydantic config."""
+
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+        # Annotating -> "DatabagModel" as the return type here doesn't sit well with pyright
+        # We are disabling this line for now and come back to it later.
+        @classmethod
+        def load(cls, databag: MutableMapping):  # type: ignore[no-untyped-def]
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True) -> Any:
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=True)
+                return databag
+
+            for key, value in self.dict(by_alias=True, exclude_defaults=True).items():  # type: ignore  # noqa
+                databag[key] = json.dumps(value)
+
+            return databag
+
+else:
+    from pydantic import ConfigDict, field_validator
+
+    input_validator = partial(field_validator, mode="before")  # type: ignore
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        model_config = ConfigDict(
+            # tolerate additional keys in databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,
+        )  # type: ignore
+        """Pydantic config."""
+
+        # Annotating -> "DatabagModel" as the return type here doesn't sit well with pyright
+        # We are disabling this line for now and come back to it later.
+        @classmethod
+        def load(cls, databag: MutableMapping):  # type: ignore[no-untyped-def]
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))  # type: ignore
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.model_fields.items()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.model_validate_json(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True) -> Any:
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(  # type: ignore
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
+
+            dct = self.model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_defaults=True,  # type: ignore
+            )
+            databag.update({k: json.dumps(v) for k, v in dct.items()})
+            return databag
+
+
+# todo: import these models from charm-relation-interfaces/ingress/v2 instead of redeclaring them
+class IngressUrl(BaseModel):
+    """Ingress url schema."""
+
+    url: AnyHttpUrl
+
+
+class IngressProviderAppData(DatabagModel):
+    """Ingress application databag schema."""
+
+    ingress: Optional[IngressUrl] = None
+
+
+class ProviderSchema(BaseModel):
+    """Provider schema for Ingress."""
+
+    app: IngressProviderAppData
+
+
+class IngressHealthCheck(BaseModel):
+    """HealthCheck schema for Ingress."""
+
+    path: str = Field(description="The health check endpoint path (required).")
+    scheme: Optional[str] = Field(
+        default=None, description="Replaces the server URL scheme for the health check endpoint."
+    )
+    hostname: Optional[str] = Field(
+        default=None, description="Hostname to be set in the health check request."
+    )
+    port: Optional[int] = Field(
+        default=None, description="Replaces the server URL port for the health check endpoint."
+    )
+    interval: str = Field(default="30s", description="Frequency of the health check calls.")
+    timeout: str = Field(default="5s", description="Maximum duration for a health check request.")
+
+
+class IngressRequirerAppData(DatabagModel):
+    """Ingress requirer application databag model."""
+
+    model: str = Field(description="The model the application is in.")
+    name: str = Field(description="the name of the app requesting ingress.")
+    port: int = Field(description="The port the app wishes to be exposed.")
+    healthcheck_params: Optional[IngressHealthCheck] = Field(
+        default=None, description="Optional health check configuration for ingress."
+    )
+
+    # fields on top of vanilla 'ingress' interface:
+    strip_prefix: Optional[bool] = Field(
+        default=False,
+        description="Whether to strip the prefix from the ingress url.",
+        alias="strip-prefix",
+    )
+    redirect_https: Optional[bool] = Field(
+        default=False,
+        description="Whether to redirect http traffic to https.",
+        alias="redirect-https",
+    )
+
+    scheme: Optional[str] = Field(
+        default="http", description="What scheme to use in the generated ingress url"
+    )
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("scheme")
+    def validate_scheme(cls, scheme: str) -> str:  # noqa: N805
+        """Validate scheme arg."""
+        if scheme not in {"http", "https", "h2c"}:
+            raise ValueError("invalid scheme: should be one of `http|https|h2c`")
+        return scheme
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("port")
+    def validate_port(cls, port: int) -> int:  # noqa: N805
+        """Validate port."""
+        assert isinstance(port, int), type(port)
+        assert 0 < port < 65535, "port out of TCP range"
+        return port
+
+
+class IngressRequirerUnitData(DatabagModel):
+    """Ingress requirer unit databag model."""
+
+    host: str = Field(description="Hostname at which the unit is reachable.")
+    ip: Optional[str] = Field(
+        None,
+        description="IP at which the unit is reachable, "
+        "IP can only be None if the IP information can't be retrieved from juju.",
+    )
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("host")
+    def validate_host(cls, host: str) -> str:  # noqa: N805
+        """Validate host."""
+        assert isinstance(host, str), type(host)
+        return host
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("ip")
+    def validate_ip(cls, ip: str) -> Optional[str]:  # noqa: N805
+        """Validate ip."""
+        if ip is None:
+            return None
+        if not isinstance(ip, str):
+            raise TypeError(f"got ip of type {type(ip)} instead of expected str")
+        try:
+            ipaddress.IPv4Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            pass
+        try:
+            ipaddress.IPv6Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            raise ValueError(f"{ip!r} is not a valid ip address")
+
+
+class RequirerSchema(BaseModel):
+    """Requirer schema for Ingress."""
+
+    app: IngressRequirerAppData
+    unit: IngressRequirerUnitData
+
+
+class IngressError(RuntimeError):
+    """Base class for custom errors raised by this library."""
+
+
+class NotReadyError(IngressError):
+    """Raised when a relation is not ready."""
+
+
+class DataValidationError(IngressError):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class _IngressPerAppBase(Object):
+    """Base class for IngressPerUnit interface classes."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+
+        self.charm: CharmBase = charm
+        self.relation_name = relation_name
+        self.app = self.charm.app
+        self.unit = self.charm.unit
+
+        observe = self.framework.observe
+        rel_events = charm.on[relation_name]
+        observe(rel_events.relation_created, self._handle_relation)
+        observe(rel_events.relation_joined, self._handle_relation)
+        observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_departed, self._handle_relation)
+        observe(rel_events.relation_broken, self._handle_relation_broken)
+        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)  # type: ignore
+        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)  # type: ignore
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this endpoint."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def _handle_relation(self, event: RelationEvent) -> None:
+        """Subclasses should implement this method to handle a relation update."""
+        pass
+
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        """Subclasses should implement this method to handle a relation breaking."""
+        pass
+
+    def _handle_upgrade_or_leader(self, event: EventBase) -> None:
+        """Subclasses should implement this method to handle upgrades or leadership change."""
+        pass
+
+
+class _IPAEvent(RelationEvent):
+    __args__: Tuple[str, ...] = ()
+    __optional_kwargs__: Dict[str, Any] = {}
+
+    @classmethod
+    def __attrs__(cls):  # type: ignore
+        return cls.__args__ + tuple(cls.__optional_kwargs__.keys())
+
+    def __init__(self, handle, relation, *args, **kwargs):  # type: ignore
+        super().__init__(handle, relation)
+
+        if not len(self.__args__) == len(args):
+            raise TypeError("expected {} args, got {}".format(len(self.__args__), len(args)))
+
+        for attr, obj in zip(self.__args__, args):
+            setattr(self, attr, obj)
+        for attr, default in self.__optional_kwargs__.items():
+            obj = kwargs.get(attr, default)
+            setattr(self, attr, obj)
+
+    def snapshot(self) -> Dict[str, Any]:
+        dct = super().snapshot()
+        for attr in self.__attrs__():
+            obj = getattr(self, attr)
+            try:
+                dct[attr] = obj
+            except ValueError as e:
+                raise ValueError(
+                    "cannot automagically serialize {}: "
+                    "override this method and do it "
+                    "manually.".format(obj)
+                ) from e
+
+        return dct
+
+    def restore(self, snapshot: Any) -> None:
+        super().restore(snapshot)
+        for attr, obj in snapshot.items():
+            setattr(self, attr, obj)
+
+
+class IngressPerAppDataProvidedEvent(_IPAEvent):
+    """Event representing that ingress data has been provided for an app."""
+
+    __args__ = ("name", "model", "hosts", "strip_prefix", "redirect_https")
+
+    if typing.TYPE_CHECKING:
+        name: Optional[str] = None
+        model: Optional[str] = None
+        # sequence of hostname, port dicts
+        hosts: Sequence["IngressRequirerUnitData"] = ()
+        strip_prefix: bool = False
+        redirect_https: bool = False
+
+
+class IngressPerAppDataRemovedEvent(RelationEvent):
+    """Event representing that ingress data has been removed for an app."""
+
+
+class IngressPerAppEndpointsUpdatedEvent(RelationEvent):
+    """Event representing that the proxied endpoints have been updated."""
+
+
+class IngressPerAppProviderEvents(ObjectEvents):
+    """Container for IPA Provider events."""
+
+    data_provided = EventSource(IngressPerAppDataProvidedEvent)
+    data_removed = EventSource(IngressPerAppDataRemovedEvent)
+    endpoints_updated = EventSource(IngressPerAppEndpointsUpdatedEvent)
+
+
+@dataclass
+class IngressRequirerData:
+    """Data exposed by the ingress requirer to the provider."""
+
+    app: "IngressRequirerAppData"
+    units: List["IngressRequirerUnitData"]
+
+
+class IngressPerAppProvider(_IngressPerAppBase):
+    """Implementation of the provider of ingress."""
+
+    on = IngressPerAppProviderEvents()  # type: ignore
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Constructor for IngressPerAppProvider.
+
+        Args:
+            charm: The charm that is instantiating the instance.
+            relation_name: The name of the relation endpoint to bind to
+                (defaults to "ingress").
+        """
+        super().__init__(charm, relation_name)
+
+    def _handle_relation(self, event: RelationEvent) -> None:
+        # created, joined or changed: if remote side has sent the required data:
+        # notify listeners.
+        if self.is_ready(event.relation):
+            data = self.get_data(event.relation)
+            self.on.data_provided.emit(  # type: ignore
+                event.relation,
+                data.app.name,
+                data.app.model,
+                [
+                    unit.dict() if PYDANTIC_IS_V1 else unit.model_dump(mode="json")
+                    for unit in data.units
+                ],
+                data.app.strip_prefix or False,
+                data.app.redirect_https or False,
+            )
+
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        self.on.data_removed.emit(event.relation, event.relation.app)  # type: ignore
+
+    def wipe_ingress_data(self, relation: Relation) -> None:
+        """Clear ingress data from relation."""
+        assert self.unit.is_leader(), "only leaders can do this"
+        try:
+            relation.data
+        except ModelError as e:
+            log.warning(
+                "error {} accessing relation data for {!r}. "
+                "Probably a ghost of a dead relation is still "
+                "lingering around.".format(e, relation.name)
+            )
+            return
+        del relation.data[self.app]["ingress"]
+        self.on.endpoints_updated.emit(relation=relation, app=relation.app)
+
+    def _get_requirer_units_data(self, relation: Relation) -> List["IngressRequirerUnitData"]:
+        """Fetch and validate the requirer's unit databag."""
+        out: List["IngressRequirerUnitData"] = []
+
+        unit: Unit
+        for unit in relation.units:
+            databag = relation.data[unit]
+            try:
+                data = IngressRequirerUnitData.load(databag)
+                out.append(cast(IngressRequirerUnitData, data))
+            except pydantic.ValidationError:
+                log.info(f"failed to validate remote unit data for {unit}")
+                raise
+        return out
+
+    @staticmethod
+    def _get_requirer_app_data(relation: Relation) -> "IngressRequirerAppData":
+        """Fetch and validate the requirer's app databag."""
+        app = relation.app
+        if app is None:
+            raise NotReadyError(relation)
+
+        databag = relation.data[app]
+        return cast(IngressRequirerAppData, IngressRequirerAppData.load(databag))
+
+    def get_data(self, relation: Relation) -> IngressRequirerData:
+        """Fetch the remote (requirer) app and units' databags."""
+        try:
+            return IngressRequirerData(
+                self._get_requirer_app_data(relation), self._get_requirer_units_data(relation)
+            )
+        except (pydantic.ValidationError, DataValidationError) as e:
+            raise DataValidationError(
+                "failed to validate ingress requirer data: %s" % str(e)
+            ) from e
+
+    def is_ready(self, relation: Optional[Relation] = None) -> bool:
+        """The Provider is ready if the requirer has sent valid data."""
+        if not relation:
+            return any(map(self.is_ready, self.relations))
+
+        try:
+            self.get_data(relation)
+        except (DataValidationError, NotReadyError) as e:
+            log.info("Provider not ready; validation error encountered: %s" % str(e))
+            return False
+        return True
+
+    def _published_url(self, relation: Relation) -> Optional["IngressProviderAppData"]:
+        """Fetch and validate this app databag; return the ingress url."""
+        if not self.is_ready(relation) or not self.unit.is_leader():
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # Also, only leader units can read own app databags.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return None
+
+        # fetch the provider's app databag
+        databag = relation.data[self.app]
+        if not databag.get("ingress"):
+            raise NotReadyError("This application did not `publish_url` yet.")
+
+        return IngressProviderAppData.load(databag)
+
+    def publish_url(self, relation: Relation, url: str) -> None:
+        """Publish to the app databag the ingress url."""
+        ingress_url = {"url": url}
+        try:
+            IngressProviderAppData(ingress=ingress_url).dump(relation.data[self.app])  # type: ignore
+            self.on.endpoints_updated.emit(relation=relation, app=relation.app)
+        except pydantic.ValidationError as e:
+            # If we cannot validate the url as valid, publish an empty databag and log the error.
+            log.error(f"Failed to validate ingress url '{url}' - got ValidationError {e}")
+            log.error(
+                (
+                    f"url was not published to ingress relation for {relation.app}."
+                    f"This error is likely due to an error or misconfiguration of the"
+                    "charm calling this library."
+                )
+            )
+            IngressProviderAppData(ingress=None).dump(relation.data[self.app])  # type: ignore
+
+    @property
+    def proxied_endpoints(self) -> Dict[str, Dict[str, str]]:
+        """Returns the ingress settings provided to applications by this IngressPerAppProvider.
+
+        For example, when this IngressPerAppProvider has provided the
+        `http://foo.bar/my-model.my-app` URL to the my-app application, the returned dictionary
+        will be:
+
+        ```
+        {
+            "my-app": {
+                "url": "http://foo.bar/my-model.my-app"
+            }
+        }
+        ```
+        """
+        results: Dict[str, Dict[str, str]] = {}
+
+        for ingress_relation in self.relations:
+            if not ingress_relation.app:
+                log.warning(
+                    (
+                        f"no app in relation {ingress_relation} when fetching proxied endpoints:"
+                        "skipping"
+                    )
+                )
+                continue
+            try:
+                ingress_data = self._published_url(ingress_relation)
+            except NotReadyError:
+                log.warning(
+                    f"no published url found in {ingress_relation}: "
+                    f"traefik didn't publish_url yet to this relation."
+                )
+                continue
+
+            if not ingress_data:
+                log.warning(f"relation {ingress_relation} not ready yet: try again in some time.")
+                continue
+
+            # Validation above means ingress cannot be None, but type checker doesn't know that.
+            ingress = cast(IngressProviderAppData, ingress_data.ingress)
+            if PYDANTIC_IS_V1:
+                results[ingress_relation.app.name] = ingress.dict()
+            else:
+                results[ingress_relation.app.name] = ingress.model_dump(mode="json")
+        return results
+
+
+class IngressPerAppReadyEvent(_IPAEvent):
+    """Event representing that ingress for an app is ready."""
+
+    __args__ = ("url",)
+    if typing.TYPE_CHECKING:
+        url: Optional[str] = None
+
+
+class IngressPerAppRevokedEvent(RelationEvent):
+    """Event representing that ingress for an app has been revoked."""
+
+
+class IngressPerAppRequirerEvents(ObjectEvents):
+    """Container for IPA Requirer events."""
+
+    ready = EventSource(IngressPerAppReadyEvent)
+    revoked = EventSource(IngressPerAppRevokedEvent)
+
+
+class IngressPerAppRequirer(_IngressPerAppBase):
+    """Implementation of the requirer of the ingress relation."""
+
+    on = IngressPerAppRequirerEvents()  # type: ignore
+
+    # used to prevent spurious urls to be sent out if the event we're currently
+    # handling is a relation-broken one.
+    _stored = StoredState()
+    _auto_data: Optional[Tuple[Optional[str], Optional[str], int]]
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        *,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: Optional[int] = None,
+        strip_prefix: bool = False,
+        redirect_https: bool = False,
+        # fixme: this is horrible UX.
+        # shall we switch to manually calling provide_ingress_requirements with all args when
+        # ready?
+        scheme: Union[Callable[[], str], str] = lambda: "http",
+        healthcheck_params: Optional[Dict[str, Any]] = None,
+    ):
+        """Constructor for IngressRequirer.
+
+        The request args can be used to specify the ingress properties when the
+        instance is created. If any are set, at least `port` is required, and
+        they will be sent to the ingress provider as soon as it is available.
+        All request args must be given as keyword args.
+
+        Args:
+            charm: The charm that is instantiating the library.
+            relation_name: The name of the relation endpoint to bind to (defaults to "ingress");
+                the relation must be of interface type "ingress" and have a limit of 1.
+            host: Hostname to be used by the ingress provider to address the requiring
+                application; if unspecified, the default Kubernetes service name will be used.
+            ip: Alternative addressing method other than host to be used by the ingress provider;
+                if unspecified, the binding address from the Juju network API will be used.
+            healthcheck_params: Optional dictionary containing health check
+                configuration parameters conforming to the IngressHealthCheck schema.
+                The dictionary must include:
+                    - "path" (str): The health check endpoint path (required).
+                It may also include:
+                    - "scheme" (Optional[str]): Replaces the server URL scheme for the health check
+                        endpoint.
+                    - "hostname" (Optional[str]): Hostname to be set in the health check request.
+                    - "port" (Optional[int]): Replaces the server URL port for the health check
+                        endpoint.
+                    - "interval" (str): Frequency of the health check calls
+                        (defaults to "30s" if omitted).
+                    - "timeout" (str): Maximum duration for a health check request
+                        (defaults to "5s" if omitted).
+                If provided, "path" is required while "interval" and "timeout" will use Traefik's
+                    defaults when not specified.
+            strip_prefix: Configure Traefik to strip the path prefix.
+            redirect_https: Redirect incoming requests to HTTPS.
+            scheme: Either a callable that returns the scheme to use when constructing the ingress
+                URL, or a string if the scheme is known and stable at charm initialization.
+
+        Request Args:
+            port: the port of the service
+        """
+        super().__init__(charm, relation_name)
+        self.charm: CharmBase = charm
+        self.healthcheck_params = healthcheck_params
+        self.relation_name = relation_name
+        self._strip_prefix = strip_prefix
+        self._redirect_https = redirect_https
+        self._get_scheme = scheme if callable(scheme) else lambda: scheme
+
+        self._stored.set_default(current_url=None)  # type: ignore
+
+        # if instantiated with a port, and we are related, then
+        # we immediately publish our ingress data  to speed up the process.
+        if port:
+            self._auto_data = host, ip, port
+        else:
+            self._auto_data = None
+
+    def _handle_relation(self, event: RelationEvent) -> None:
+        # created, joined or changed: if we have auto data: publish it
+        self._publish_auto_data()
+        if self.is_ready():
+            # Avoid spurious events, emit only when there is a NEW URL available
+            new_url = (
+                None
+                if isinstance(event, RelationBrokenEvent)
+                else self._get_url_from_relation_data()
+            )
+            if self._stored.current_url != new_url:  # type: ignore
+                self._stored.current_url = new_url  # type: ignore
+                self.on.ready.emit(event.relation, new_url)  # type: ignore
+
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        self._stored.current_url = None  # type: ignore
+        self.on.revoked.emit(relation=event.relation, app=event.relation.app)  # type: ignore
+
+    def _handle_upgrade_or_leader(self, event: EventBase) -> None:
+        """On upgrade/leadership change: ensure we publish the data we have."""
+        self._publish_auto_data()
+
+    def is_ready(self) -> bool:
+        """The Requirer is ready if the Provider has sent valid data."""
+        try:
+            return bool(self._get_url_from_relation_data())
+        except DataValidationError as e:
+            log.debug("Requirer not ready; validation error encountered: %s" % str(e))
+            return False
+
+    def _publish_auto_data(self) -> None:
+        if self._auto_data:
+            host, ip, port = self._auto_data
+            self.provide_ingress_requirements(host=host, ip=ip, port=port)
+
+    def provide_ingress_requirements(
+        self,
+        *,
+        scheme: Optional[str] = None,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: int,
+    ) -> None:
+        """Publishes the data that Traefik needs to provide ingress.
+
+        Args:
+            scheme: Scheme to be used; if unspecified, use the one used by __init__.
+            host: Hostname to be used by the ingress provider to address the
+             requirer unit; if unspecified, FQDN will be used instead
+            ip: Alternative addressing method other than host to be used by the ingress provider.
+                if unspecified, binding address from juju network API will be used.
+            port: the port of the service (required)
+        """
+        for relation in self.relations:
+            self._provide_ingress_requirements(scheme, host, ip, port, relation)
+
+    def _provide_ingress_requirements(
+        self,
+        scheme: Optional[str],
+        host: Optional[str],
+        ip: Optional[str],
+        port: int,
+        relation: Relation,
+    ) -> None:
+        if self.unit.is_leader():
+            self._publish_app_data(scheme, port, relation)
+
+        self._publish_unit_data(host, ip, relation)
+
+    def _publish_unit_data(
+        self,
+        host: Optional[str],
+        ip: Optional[str],
+        relation: Relation,
+    ) -> None:
+        if not host:
+            host = socket.getfqdn()
+
+        if ip is None:
+            network_binding = self.charm.model.get_binding(relation)
+            if (
+                network_binding is not None
+                and (bind_address := network_binding.network.bind_address) is not None
+            ):
+                ip = str(bind_address)
+            else:
+                log.error("failed to retrieve ip information from juju")
+
+        unit_databag = relation.data[self.unit]
+        try:
+            IngressRequirerUnitData(host=host, ip=ip).dump(unit_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate unit data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    def _publish_app_data(
+        self,
+        scheme: Optional[str],
+        port: int,
+        relation: Relation,
+    ) -> None:
+        # assumes leadership!
+        app_databag = relation.data[self.app]
+
+        if not scheme:
+            # If scheme was not provided, use the one given to the constructor.
+            scheme = self._get_scheme()
+
+        try:
+            # Ignore pyright errors since pyright does not like aliases.
+            IngressRequirerAppData(  # type: ignore
+                model=self.model.name,
+                name=self.app.name,
+                scheme=scheme,
+                port=port,
+                strip_prefix=self._strip_prefix,  # type: ignore
+                redirect_https=self._redirect_https,  # type: ignore
+                healthcheck_params=(
+                    IngressHealthCheck(**self.healthcheck_params)
+                    if self.healthcheck_params
+                    else None
+                ),
+            ).dump(app_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate app data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
+    @property
+    def relation(self) -> Optional[Relation]:
+        """The established Relation instance, or None."""
+        return self.relations[0] if self.relations else None
+
+    def _get_url_from_relation_data(self) -> Optional[str]:
+        """The full ingress URL to reach the charm application.
+
+        Returns None if the URL isn't available yet.
+        """
+        relation = self.relation
+        if not relation or not relation.app:
+            return None
+
+        # fetch the provider's app databag
+        try:
+            databag = relation.data[relation.app]
+        except ModelError as e:
+            log.debug(
+                f"Error {e} attempting to read remote app data; "
+                f"probably we are in a relation_departed hook"
+            )
+            return None
+
+        if not databag:  # not ready yet
+            return None
+
+        ingress = cast(IngressProviderAppData, IngressProviderAppData.load(databag)).ingress
+        if ingress is None:
+            return None
+
+        return str(ingress.url)
+
+    @property
+    def url(self) -> Optional[str]:
+        """The full ingress URL to reach the charm application.
+
+        Returns None if the URL isn't available yet.
+        """
+        data = (
+            typing.cast(Optional[str], self._stored.current_url)  # type: ignore
+            or self._get_url_from_relation_data()
+        )
+        return data

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -42,6 +42,9 @@ requires:
   nginx-route:
     interface: nginx-route
     limit: 1
+  ingress:
+    interface: ingress
+    limit: 1
 
 containers:
   temporal-ui:

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,6 +10,7 @@ import logging
 import os
 
 from charms.nginx_ingress_integrator.v0.nginx_route import require_nginx_route
+from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from jinja2 import Environment, FileSystemLoader
 from ops import main, pebble
 from ops.charm import CharmBase
@@ -78,11 +79,26 @@ class TemporalUiK8SOperatorCharm(CharmBase):
         self.framework.observe(self.on.restart_action, self._on_restart)
         self.framework.observe(self.on.update_status, self._on_update_status)
 
-        # Handle Ingress.
+        # Handle Nginx Ingress.
         self._require_nginx_route()
+
+        # Handle Traefik Ingress.
+        self.ingress = IngressPerAppRequirer(
+            self,
+            relation_name="ingress",
+            port=self.config["port"],
+            strip_prefix=True,
+        )
+        self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
+        self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
 
     def _require_nginx_route(self):
         """Require nginx-route relation based on current configuration."""
+        if self.model.get_relation("ingress") and self.model.get_relation("nginx-route"):
+            self.unit.status = BlockedStatus(
+                "Only one ingress solution is allowed - remove the ingress or the nginx-route relation."
+            )
+            return
         require_nginx_route(
             charm=self,
             service_hostname=self.external_hostname,
@@ -91,6 +107,26 @@ class TemporalUiK8SOperatorCharm(CharmBase):
             tls_secret_name=self.config["tls-secret-name"],
             backend_protocol="HTTP",
         )
+
+    @log_event_handler(logger)
+    def _on_ingress_ready(self, event):
+        """Handle Traefik ingress ready event.
+
+        Args:
+            event: The event triggered when ingress is ready.
+        """
+        logger.info("Ingress is ready: %s", self.ingress.url)
+        self._update(event)
+
+    @log_event_handler(logger)
+    def _on_ingress_revoked(self, event):
+        """Handle Traefik ingress revoked event.
+
+        Args:
+            event: The event triggered when ingress is revoked.
+        """
+        logger.info("Ingress revoked")
+        self._update(event)
 
     @log_event_handler(logger)
     def _on_install(self, event):
@@ -259,7 +295,7 @@ class TemporalUiK8SOperatorCharm(CharmBase):
                 if self.config[param].strip() == "":
                     raise ValueError(f"Invalid config: {param} value missing")
 
-            if not self.model.relations.get("nginx-route"):
+            if not self.model.relations.get("nginx-route") and not self.model.relations.get("ingress"):
                 raise ValueError("Invalid config: auth cannot work without ingress relation")
 
     @log_event_handler(logger)

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,11 +94,6 @@ class TemporalUiK8SOperatorCharm(CharmBase):
 
     def _require_nginx_route(self):
         """Require nginx-route relation based on current configuration."""
-        if self.model.get_relation("ingress") and self.model.get_relation("nginx-route"):
-            self.unit.status = BlockedStatus(
-                "Only one ingress solution is allowed - remove the ingress or the nginx-route relation"
-            )
-            return
         require_nginx_route(
             charm=self,
             service_hostname=self.external_hostname,
@@ -289,6 +284,8 @@ class TemporalUiK8SOperatorCharm(CharmBase):
             raise ValueError("ui:temporal relation: not available")
         if not self._state.server_status == "ready":
             raise ValueError("ui:temporal relation: server is not ready")
+        if self.model.relations.get("ingress") and self.model.relations.get("nginx-route"):
+            raise ValueError("Only one ingress solution is allowed - remove the ingress or the nginx-route relation")
 
         if self.config["auth-enabled"]:
             for param in REQUIRED_AUTH_PARAMETERS:

--- a/src/charm.py
+++ b/src/charm.py
@@ -96,7 +96,7 @@ class TemporalUiK8SOperatorCharm(CharmBase):
         """Require nginx-route relation based on current configuration."""
         if self.model.get_relation("ingress") and self.model.get_relation("nginx-route"):
             self.unit.status = BlockedStatus(
-                "Only one ingress solution is allowed - remove the ingress or the nginx-route relation."
+                "Only one ingress solution is allowed - remove the ingress or the nginx-route relation"
             )
             return
         require_nginx_route(

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -121,3 +121,8 @@ def ui_relation():
 @pytest.fixture(scope="function")
 def nginx_relation():
     return ops.testing.Relation("nginx-route")
+
+
+@pytest.fixture(scope="function")
+def traefik_relation():
+    return ops.testing.Relation("ingress")

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import dataclasses
 import json
 
 import ops.testing
@@ -126,3 +127,27 @@ def nginx_relation():
 @pytest.fixture(scope="function")
 def traefik_relation():
     return ops.testing.Relation("ingress")
+
+
+@pytest.fixture
+def all_required_relations(peer_relation, ui_relation):
+    return [peer_relation, ui_relation]
+
+
+@pytest.fixture
+def state(temporal_ui_container, all_required_relations):
+    return ops.testing.State(
+        leader=True,
+        containers=[temporal_ui_container],
+        relations=all_required_relations,
+    )
+
+
+@pytest.fixture
+def nginx_state(state, nginx_relation):
+    return dataclasses.replace(state, relations=state.relations | {nginx_relation})
+
+
+@pytest.fixture
+def traefik_state(state, traefik_relation):
+    return dataclasses.replace(state, relations=state.relations | {traefik_relation})

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -32,6 +32,24 @@ def state(temporal_ui_container, all_required_relations):
     )
 
 
+@pytest.fixture
+def dual_ingress_state(state, traefik_relation):
+    return dataclasses.replace(state, relations=state.relations | {traefik_relation})
+
+
+@pytest.fixture
+def traefik_state(state, traefik_relation):
+    relations_without_nginx = frozenset(
+        relation for relation in state.relations if relation.endpoint != "nginx-route"
+    )
+    return dataclasses.replace(state, relations=relations_without_nginx | {traefik_relation})
+
+
+@pytest.fixture
+def traefik_auth_state(traefik_state, config_with_auth_enabled):
+    return dataclasses.replace(traefik_state, config=config_with_auth_enabled)
+
+
 def test_smoke(context, state):
     context.run(context.on.start(), state)
 
@@ -310,14 +328,12 @@ def test_missing_pebble_plan(context, state, temporal_ui_container, temporal_ui_
 
 def test_blocked_on_two_ingresses(
     context,
-    state,
+    dual_ingress_state,
     temporal_ui_container,
     temporal_ui_container_initialized,
     traefik_relation,
 ):
-    state = dataclasses.replace(state, relations=state.relations | {traefik_relation})
-
-    state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
+    state_out = context.run(context.on.pebble_ready(temporal_ui_container), dual_ingress_state)
 
     state_out = dataclasses.replace(state_out, containers=[temporal_ui_container_initialized])
     state_out = context.run(context.on.relation_changed(traefik_relation), state_out)
@@ -329,19 +345,12 @@ def test_blocked_on_two_ingresses(
 
 def test_traefik_ingress_ready(
     context,
-    state,
+    traefik_state,
     temporal_ui_container,
     temporal_ui_container_initialized,
     ui_relation,
-    traefik_relation,
 ):
-    state = dataclasses.replace(
-        state,
-        relations=frozenset(relation for relation in state.relations if relation.endpoint != "nginx-route"),
-    )
-    state = dataclasses.replace(state, relations=state.relations | {traefik_relation})
-
-    state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
+    state_out = context.run(context.on.pebble_ready(temporal_ui_container), traefik_state)
 
     state_out = dataclasses.replace(state_out, containers=[temporal_ui_container_initialized])
     state_out = context.run(context.on.relation_changed(ui_relation), state_out)
@@ -352,22 +361,13 @@ def test_traefik_ingress_ready(
 
 def test_auth_with_traefik_ingress(
     context,
-    state,
+    traefik_auth_state,
     temporal_ui_container,
     temporal_ui_container_initialized,
     ui_relation,
-    traefik_relation,
-    config_with_auth_enabled,
     external_hostname,
 ):
-    state = dataclasses.replace(
-        state,
-        relations=frozenset(relation for relation in state.relations if relation.endpoint != "nginx-route"),
-    )
-    state = dataclasses.replace(state, relations=state.relations | {traefik_relation})
-    state = dataclasses.replace(state, config=config_with_auth_enabled)
-
-    state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
+    state_out = context.run(context.on.pebble_ready(temporal_ui_container), traefik_auth_state)
 
     state_out = dataclasses.replace(state_out, containers=[temporal_ui_container_initialized])
     state_out = context.run(context.on.relation_changed(ui_relation), state_out)

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -306,3 +306,147 @@ def test_missing_pebble_plan(context, state, temporal_ui_container, temporal_ui_
         assert state_out.unit_status == ops.MaintenanceStatus("replanning application")
 
         assert state_out.get_container("temporal-ui").plan.to_dict() is not None
+
+
+def test_blocked_on_two_ingresses(
+    context,
+    temporal_ui_container,
+    temporal_ui_container_initialized,
+    peer_relation,
+    ui_relation,
+    nginx_relation,
+    traefik_relation,
+):
+    state = ops.testing.State(
+        leader=True,
+        containers=[temporal_ui_container],
+        relations=[peer_relation, ui_relation, nginx_relation, traefik_relation],
+    )
+
+    state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
+
+    state_out = dataclasses.replace(state_out, containers=[temporal_ui_container_initialized])
+    state_out = context.run(context.on.relation_changed(traefik_relation), state_out)
+
+    assert state_out.unit_status == ops.BlockedStatus(
+        "Only one ingress solution is allowed - remove the ingress or the nginx-route relation."
+    )
+
+
+def test_traefik_ingress_ready(
+    context,
+    temporal_ui_container,
+    temporal_ui_container_initialized,
+    peer_relation,
+    ui_relation,
+    traefik_relation,
+):
+    state = ops.testing.State(
+        leader=True,
+        containers=[temporal_ui_container],
+        relations=[peer_relation, ui_relation, traefik_relation],
+    )
+
+    state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
+
+    state_out = dataclasses.replace(state_out, containers=[temporal_ui_container_initialized])
+    state_out = context.run(context.on.relation_changed(ui_relation), state_out)
+
+    assert state_out.unit_status == ops.MaintenanceStatus("replanning application")
+
+    assert state_out.get_container("temporal-ui").plan.to_dict() == {
+        "services": {
+            "temporal-ui": {
+                "summary": "temporal ui",
+                "command": "ui-server --root /home/ui-server --env charm start",
+                "startup": "enabled",
+                "override": "replace",
+                "environment": {
+                    "LOG_LEVEL": "info",
+                    "TEMPORAL_UI_PORT": 8080,
+                    "TEMPORAL_DEFAULT_NAMESPACE": "default",
+                    "TEMPORAL_AUTH_ENABLED": False,
+                    "TEMPORAL_WORKFLOW_CANCEL_DISABLED": False,
+                    "TEMPORAL_WORKFLOW_RESET_DISABLED": False,
+                    "TEMPORAL_WORKFLOW_SIGNAL_DISABLED": False,
+                    "TEMPORAL_WORKFLOW_TERMINATE_DISABLED": False,
+                    "TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS": False,
+                    "TEMPORAL_CODEC_ENDPOINT": "",
+                    "TEMPORAL_CODEC_PASS_ACCESS_TOKEN": False,  # nosec B105
+                    "TEMPORAL_BATCH_ACTIONS_DISABLED": False,
+                },
+                "on-check-failure": {"up": "ignore"},
+            }
+        },
+        "checks": {
+            "up": {
+                "http": {"url": "http://localhost:8080/"},
+                "override": "replace",
+                "period": "10s",
+            }
+        },
+    }
+
+
+def test_auth_with_traefik_ingress(
+    context,
+    temporal_ui_container,
+    temporal_ui_container_initialized,
+    peer_relation,
+    ui_relation,
+    traefik_relation,
+    config_with_auth_enabled,
+    external_hostname,
+):
+    state = ops.testing.State(
+        leader=True,
+        containers=[temporal_ui_container],
+        relations=[peer_relation, ui_relation, traefik_relation],
+    )
+
+    state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
+
+    state_out = dataclasses.replace(state_out, containers=[temporal_ui_container_initialized])
+    state_out = context.run(context.on.relation_changed(ui_relation), state_out)
+
+    state_out = dataclasses.replace(state_out, config=config_with_auth_enabled)
+
+    assert sorted(state_out.get_container("temporal-ui").plan.to_dict()) == sorted(
+        {
+            "services": {
+                "temporal-ui": {
+                    "summary": "temporal ui",
+                    "command": "ui-server --root /home/ui-server --env charm start",
+                    "startup": "enabled",
+                    "override": "replace",
+                    "environment": {
+                        "LOG_LEVEL": "info",
+                        "TEMPORAL_UI_PORT": 8080,
+                        "TEMPORAL_DEFAULT_NAMESPACE": "default",
+                        "TEMPORAL_AUTH_ENABLED": True,
+                        "TEMPORAL_AUTH_PROVIDER_URL": "some-provider-url",
+                        "TEMPORAL_AUTH_CLIENT_ID": "some-client-id",
+                        "TEMPORAL_AUTH_CLIENT_SECRET": "some-client-secret",  # nosec B105
+                        "TEMPORAL_AUTH_SCOPES": "[openid,profile,email]",
+                        "TEMPORAL_AUTH_CALLBACK_URL": f"https://{external_hostname}/auth/sso/callback",
+                        "TEMPORAL_WORKFLOW_CANCEL_DISABLED": False,
+                        "TEMPORAL_WORKFLOW_RESET_DISABLED": False,
+                        "TEMPORAL_WORKFLOW_SIGNAL_DISABLED": False,
+                        "TEMPORAL_WORKFLOW_TERMINATE_DISABLED": False,
+                        "TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS": False,
+                        "TEMPORAL_CODEC_ENDPOINT": "",
+                        "TEMPORAL_CODEC_PASS_ACCESS_TOKEN": False,  # nosec B105
+                        "TEMPORAL_BATCH_ACTIONS_DISABLED": False,
+                    },
+                    "on-check-failure": {"up": "ignore"},
+                }
+            },
+            "checks": {
+                "up": {
+                    "http": {"url": "http://localhost:8080/"},
+                    "override": "replace",
+                    "period": "10s",
+                }
+            },
+        }
+    )

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -14,41 +14,6 @@ logger = logging.getLogger(__name__)
 UI_PORT = "8080"
 
 
-@pytest.fixture
-def all_required_relations(peer_relation, ui_relation, nginx_relation):
-    return [
-        peer_relation,
-        ui_relation,
-        nginx_relation,
-    ]
-
-
-@pytest.fixture
-def state(temporal_ui_container, all_required_relations):
-    return ops.testing.State(
-        leader=True,
-        containers=[temporal_ui_container],
-        relations=all_required_relations,
-    )
-
-
-@pytest.fixture
-def dual_ingress_state(state, traefik_relation):
-    return dataclasses.replace(state, relations=state.relations | {traefik_relation})
-
-
-@pytest.fixture
-def traefik_state(state, traefik_relation):
-    relations_without_nginx = frozenset(
-        relation for relation in state.relations if relation.endpoint != "nginx-route"
-    )
-    return dataclasses.replace(state, relations=relations_without_nginx | {traefik_relation})
-
-
-@pytest.fixture
-def traefik_auth_state(traefik_state, config_with_auth_enabled):
-    return dataclasses.replace(traefik_state, config=config_with_auth_enabled)
-
 
 def test_smoke(context, state):
     context.run(context.on.start(), state)
@@ -78,7 +43,7 @@ def test_blocked_by_peer_relation_not_ready(
 
 def test_ingress(
     context,
-    state,
+    nginx_state,
     temporal_ui_container,
     config,
     temporal_ui_container_initialized,
@@ -87,7 +52,7 @@ def test_ingress(
     external_hostname,
     tls_secret_name,
 ):
-    state = dataclasses.replace(state, config={})
+    state = dataclasses.replace(nginx_state, config={})
 
     state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
 
@@ -187,14 +152,14 @@ def test_ready(context, state, temporal_ui_container, temporal_ui_container_init
 
 def test_auth(
     context,
-    state,
+    nginx_state,
     temporal_ui_container,
     temporal_ui_container_initialized,
     ui_relation,
     config_with_auth_enabled,
     external_hostname,
 ):
-    state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
+    state_out = context.run(context.on.pebble_ready(temporal_ui_container), nginx_state)
 
     state_out = dataclasses.replace(state_out, containers=[temporal_ui_container_initialized])
     state_out = context.run(context.on.relation_changed(ui_relation), state_out)
@@ -328,12 +293,13 @@ def test_missing_pebble_plan(context, state, temporal_ui_container, temporal_ui_
 
 def test_blocked_on_two_ingresses(
     context,
-    dual_ingress_state,
+    nginx_state,
     temporal_ui_container,
     temporal_ui_container_initialized,
     traefik_relation,
 ):
-    state_out = context.run(context.on.pebble_ready(temporal_ui_container), dual_ingress_state)
+    state = dataclasses.replace(nginx_state, relations=nginx_state.relations | {traefik_relation})
+    state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
 
     state_out = dataclasses.replace(state_out, containers=[temporal_ui_container_initialized])
     state_out = context.run(context.on.relation_changed(traefik_relation), state_out)
@@ -361,13 +327,15 @@ def test_traefik_ingress_ready(
 
 def test_auth_with_traefik_ingress(
     context,
-    traefik_auth_state,
+    traefik_state,
     temporal_ui_container,
     temporal_ui_container_initialized,
     ui_relation,
+    config_with_auth_enabled,
     external_hostname,
 ):
-    state_out = context.run(context.on.pebble_ready(temporal_ui_container), traefik_auth_state)
+    state = dataclasses.replace(traefik_state, config=config_with_auth_enabled)
+    state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
 
     state_out = dataclasses.replace(state_out, containers=[temporal_ui_container_initialized])
     state_out = context.run(context.on.relation_changed(ui_relation), state_out)

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -310,18 +310,12 @@ def test_missing_pebble_plan(context, state, temporal_ui_container, temporal_ui_
 
 def test_blocked_on_two_ingresses(
     context,
+    state,
     temporal_ui_container,
     temporal_ui_container_initialized,
-    peer_relation,
-    ui_relation,
-    nginx_relation,
     traefik_relation,
 ):
-    state = ops.testing.State(
-        leader=True,
-        containers=[temporal_ui_container],
-        relations=[peer_relation, ui_relation, nginx_relation, traefik_relation],
-    )
+    state = dataclasses.replace(state, relations=state.relations | {traefik_relation})
 
     state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
 
@@ -329,23 +323,23 @@ def test_blocked_on_two_ingresses(
     state_out = context.run(context.on.relation_changed(traefik_relation), state_out)
 
     assert state_out.unit_status == ops.BlockedStatus(
-        "Only one ingress solution is allowed - remove the ingress or the nginx-route relation."
+        "Only one ingress solution is allowed - remove the ingress or the nginx-route relation"
     )
 
 
 def test_traefik_ingress_ready(
     context,
+    state,
     temporal_ui_container,
     temporal_ui_container_initialized,
-    peer_relation,
     ui_relation,
     traefik_relation,
 ):
-    state = ops.testing.State(
-        leader=True,
-        containers=[temporal_ui_container],
-        relations=[peer_relation, ui_relation, traefik_relation],
+    state = dataclasses.replace(
+        state,
+        relations=frozenset(relation for relation in state.relations if relation.endpoint != "nginx-route"),
     )
+    state = dataclasses.replace(state, relations=state.relations | {traefik_relation})
 
     state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
 
@@ -353,100 +347,35 @@ def test_traefik_ingress_ready(
     state_out = context.run(context.on.relation_changed(ui_relation), state_out)
 
     assert state_out.unit_status == ops.MaintenanceStatus("replanning application")
-
-    assert state_out.get_container("temporal-ui").plan.to_dict() == {
-        "services": {
-            "temporal-ui": {
-                "summary": "temporal ui",
-                "command": "ui-server --root /home/ui-server --env charm start",
-                "startup": "enabled",
-                "override": "replace",
-                "environment": {
-                    "LOG_LEVEL": "info",
-                    "TEMPORAL_UI_PORT": 8080,
-                    "TEMPORAL_DEFAULT_NAMESPACE": "default",
-                    "TEMPORAL_AUTH_ENABLED": False,
-                    "TEMPORAL_WORKFLOW_CANCEL_DISABLED": False,
-                    "TEMPORAL_WORKFLOW_RESET_DISABLED": False,
-                    "TEMPORAL_WORKFLOW_SIGNAL_DISABLED": False,
-                    "TEMPORAL_WORKFLOW_TERMINATE_DISABLED": False,
-                    "TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS": False,
-                    "TEMPORAL_CODEC_ENDPOINT": "",
-                    "TEMPORAL_CODEC_PASS_ACCESS_TOKEN": False,  # nosec B105
-                    "TEMPORAL_BATCH_ACTIONS_DISABLED": False,
-                },
-                "on-check-failure": {"up": "ignore"},
-            }
-        },
-        "checks": {
-            "up": {
-                "http": {"url": "http://localhost:8080/"},
-                "override": "replace",
-                "period": "10s",
-            }
-        },
-    }
+    assert state_out.get_container("temporal-ui").service_statuses["temporal-ui"] == ops.pebble.ServiceStatus.ACTIVE
 
 
 def test_auth_with_traefik_ingress(
     context,
+    state,
     temporal_ui_container,
     temporal_ui_container_initialized,
-    peer_relation,
     ui_relation,
     traefik_relation,
     config_with_auth_enabled,
     external_hostname,
 ):
-    state = ops.testing.State(
-        leader=True,
-        containers=[temporal_ui_container],
-        relations=[peer_relation, ui_relation, traefik_relation],
+    state = dataclasses.replace(
+        state,
+        relations=frozenset(relation for relation in state.relations if relation.endpoint != "nginx-route"),
     )
+    state = dataclasses.replace(state, relations=state.relations | {traefik_relation})
+    state = dataclasses.replace(state, config=config_with_auth_enabled)
 
     state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
 
     state_out = dataclasses.replace(state_out, containers=[temporal_ui_container_initialized])
     state_out = context.run(context.on.relation_changed(ui_relation), state_out)
 
-    state_out = dataclasses.replace(state_out, config=config_with_auth_enabled)
-
-    assert sorted(state_out.get_container("temporal-ui").plan.to_dict()) == sorted(
-        {
-            "services": {
-                "temporal-ui": {
-                    "summary": "temporal ui",
-                    "command": "ui-server --root /home/ui-server --env charm start",
-                    "startup": "enabled",
-                    "override": "replace",
-                    "environment": {
-                        "LOG_LEVEL": "info",
-                        "TEMPORAL_UI_PORT": 8080,
-                        "TEMPORAL_DEFAULT_NAMESPACE": "default",
-                        "TEMPORAL_AUTH_ENABLED": True,
-                        "TEMPORAL_AUTH_PROVIDER_URL": "some-provider-url",
-                        "TEMPORAL_AUTH_CLIENT_ID": "some-client-id",
-                        "TEMPORAL_AUTH_CLIENT_SECRET": "some-client-secret",  # nosec B105
-                        "TEMPORAL_AUTH_SCOPES": "[openid,profile,email]",
-                        "TEMPORAL_AUTH_CALLBACK_URL": f"https://{external_hostname}/auth/sso/callback",
-                        "TEMPORAL_WORKFLOW_CANCEL_DISABLED": False,
-                        "TEMPORAL_WORKFLOW_RESET_DISABLED": False,
-                        "TEMPORAL_WORKFLOW_SIGNAL_DISABLED": False,
-                        "TEMPORAL_WORKFLOW_TERMINATE_DISABLED": False,
-                        "TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS": False,
-                        "TEMPORAL_CODEC_ENDPOINT": "",
-                        "TEMPORAL_CODEC_PASS_ACCESS_TOKEN": False,  # nosec B105
-                        "TEMPORAL_BATCH_ACTIONS_DISABLED": False,
-                    },
-                    "on-check-failure": {"up": "ignore"},
-                }
-            },
-            "checks": {
-                "up": {
-                    "http": {"url": "http://localhost:8080/"},
-                    "override": "replace",
-                    "period": "10s",
-                }
-            },
-        }
-    )
+    env = state_out.get_container("temporal-ui").plan.to_dict()["services"]["temporal-ui"]["environment"]
+    assert env["TEMPORAL_AUTH_ENABLED"] is True
+    assert env["TEMPORAL_AUTH_PROVIDER_URL"] == "some-provider-url"
+    assert env["TEMPORAL_AUTH_CLIENT_ID"] == "some-client-id"
+    assert env["TEMPORAL_AUTH_CLIENT_SECRET"] == "some-client-secret"  # nosec B105
+    assert env["TEMPORAL_AUTH_CALLBACK_URL"] == f"https://{external_hostname}/auth/sso/callback"
+    assert state_out.get_container("temporal-ui").service_statuses["temporal-ui"] == ops.pebble.ServiceStatus.ACTIVE

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -325,25 +325,3 @@ def test_traefik_ingress_ready(
     assert state_out.get_container("temporal-ui").service_statuses["temporal-ui"] == ops.pebble.ServiceStatus.ACTIVE
 
 
-def test_auth_with_traefik_ingress(
-    context,
-    traefik_state,
-    temporal_ui_container,
-    temporal_ui_container_initialized,
-    ui_relation,
-    config_with_auth_enabled,
-    external_hostname,
-):
-    state = dataclasses.replace(traefik_state, config=config_with_auth_enabled)
-    state_out = context.run(context.on.pebble_ready(temporal_ui_container), state)
-
-    state_out = dataclasses.replace(state_out, containers=[temporal_ui_container_initialized])
-    state_out = context.run(context.on.relation_changed(ui_relation), state_out)
-
-    env = state_out.get_container("temporal-ui").plan.to_dict()["services"]["temporal-ui"]["environment"]
-    assert env["TEMPORAL_AUTH_ENABLED"] is True
-    assert env["TEMPORAL_AUTH_PROVIDER_URL"] == "some-provider-url"
-    assert env["TEMPORAL_AUTH_CLIENT_ID"] == "some-client-id"
-    assert env["TEMPORAL_AUTH_CLIENT_SECRET"] == "some-client-secret"  # nosec B105
-    assert env["TEMPORAL_AUTH_CALLBACK_URL"] == f"https://{external_hostname}/auth/sso/callback"
-    assert state_out.get_container("temporal-ui").service_statuses["temporal-ui"] == ops.pebble.ServiceStatus.ACTIVE


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Add traefik-k8s as an ingress option for the Temporal Web UI alongside the existing Nginx Ingress Integrator. HTTP only (no TLS for now due to upstream constraints tracked in canonical/traefik-k8s-operator#305).

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->
Preconditions:
- Set a valid history shard count on temporal-k8s (positive power of 2), e.g.:
  `juju config temporal-k8s num-history-shards=1`
- Ensure only one ingress relation is present for temporal-ui-k8s during validation (`ingress` or `nginx-route`, not both).

1. Build and deploy temporal-ui-k8s from this branch.
2. Deploy required dependencies and integrate core Temporal relations
```
   juju deploy temporal-k8s --channel edge
   juju deploy temporal-admin-k8s --channel edge
   juju deploy postgresql-k8s --channel 14/stable --trust
   juju deploy traefik-k8s --channel latest/stable --trust

   juju integrate temporal-k8s:db postgresql-k8s:database
   juju integrate temporal-k8s:visibility postgresql-k8s:database
   juju integrate temporal-k8s:admin temporal-admin-k8s:admin
   juju integrate temporal-ui-k8s:ui temporal-k8s:ui
```
3. Integrate Traefik with the UI charm:
```
   juju integrate temporal-ui-k8s:ingress traefik-k8s:ingress
```

4. Wait for the model to settle:
```
   juju status --relations
```

5. Get Traefik proxied endpoints:
```
   juju run traefik-k8s/0 show-proxied-endpoints
```
Example output:
```
   proxied-endpoints: '{"traefik-k8s":{"url":"http://10.64.140.43"},"temporal-ui-k8s":{"url":"http://10.64.140.43/temporal-ui-k8s"}}'
```
6. Verify UI readiness through Traefik (HTTP, no TLS):
```
   curl -i <temporal-ui-k8s-url>/-/ready
```
Expected: HTTP/1.1 200 OK


7. Verify dual-ingress guard (Nginx + Traefik not allowed together):
```
   juju deploy nginx-ingress-integrator --trust
   juju integrate temporal-ui-k8s:nginx-route nginx-ingress-integrator:nginx-route
   juju status temporal-ui-k8s
```
Expected:
temporal-ui-k8s becomes blocked with message:
`Only one ingress solution is allowed - remove the ingress or the nginx-route relation`

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [X] Unit tests added or updated
- [X] Integration tests added or updated
- [ ] Documentation updated
