### PR TITLE
[WF-343] Expose temporal-host-info endpoint in Terraform requires output

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,7 +10,8 @@ output "provides" {
 
 output "requires" {
   value = {
-    ingress     = "ingress"
-    nginx_route = "nginx-route"
+    ingress            = "ingress"
+    nginx_route        = "nginx-route"
+    temporal_host_info = "temporal-host-info"
   }
 }


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Ensure `terraform/outputs.tf` exposes `temporal_host_info = "temporal-host-info"` under `output "requires"` so bundles can reference `module.<...>.requires.temporal_host_info` for `temporal-host-info` integrations with Temporal frontend.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->
No charm behaviour change, Terraform module only.

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
