### PR TITLE
chore(tests): bump version to deploy/refresh from

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,7 +10,12 @@ import pytest
 import yaml
 
 POSTGRESQL_K8S_CHANNEL = "14/stable"
-TEMPORAL_CHANNEL = "1.23/edge"
+
+# Temporal charm channels. Bump these when the charms migrate to a new track
+# (e.g. 1.23 -> 1.31).
+TEMPORAL_CHANNEL = "1.23/edge"  # server/admin dependencies and the default ui deploy
+TEMPORAL_UI_LATEST_RELEASE_CHANNEL = "1.23/stable"  # published ui release the refresh test upgrades from
+
 TEMPORAL_SERVER_JUJU_APP = "temporal-k8s"
 
 METADATA = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
@@ -47,9 +52,8 @@ def deploy_temporal_stack(
         temporal_server_channel: channel for temporal-k8s
         temporal_admin_channel: channel for temporal-admin-k8s
         temporal_ui_channel: channel for temporal-ui-k8s
-        integrate_host_info: whether to integrate the temporal-host-info relation.
-            Set to False when deploying temporal-ui-k8s from latest/edge (pre-dates
-            the relation); the test is responsible for integrating after refresh.
+        integrate_host_info: whether to integrate the temporal-host-info relation
+            during deployment (default True).
     """
     juju.model_config(
         values={
@@ -113,12 +117,13 @@ def deploy_temporal_stack(
 
 @pytest.fixture(scope="module")
 def ui_latest_track(juju: jubilant.Juju):
-    """Deploy the temporal stack with temporal-ui from the latest/edge track.
+    """Deploy the temporal stack with temporal-ui from the latest supported release.
 
-    temporal-host-info is not integrated here because the latest/edge revision
-    pre-dates that relation. The refresh test integrates it after refreshing to 1.23+.
+    temporal-host-info is integrated during deployment because the latest supported
+    release already requires the relation, so the charm would otherwise stay blocked.
+    The refresh test then upgrades this deployment to the newer, locally built charm.
     """
-    deploy_temporal_stack(juju, temporal_ui_channel="latest/edge", integrate_host_info=False)
+    deploy_temporal_stack(juju, temporal_ui_channel=TEMPORAL_UI_LATEST_RELEASE_CHANNEL)
 
     return "temporal-ui-k8s"
 

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -1,18 +1,17 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Test to ensure successful refreshes from latest track to the 1.23 track."""
+"""Test to ensure successful refreshes from the latest supported release to the newer charm."""
 
 import logging
 
 import jubilant
-from conftest import TEMPORAL_SERVER_JUJU_APP
 
 logger = logging.getLogger(__name__)
 
 
 def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, ui_latest_track, charm_path, charm_resources):
-    """Test to refresh from latest track to the 1.23 track."""
+    """Refresh from the latest supported temporal-ui-k8s release to the local build."""
     juju.refresh(
         ui_latest_track,
         path=charm_path,
@@ -20,14 +19,6 @@ def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, ui_latest_track, charm
         base="ubuntu@24.04",
     )
 
-    # Wait for the refreshed charm to settle: it requires temporal-host-info and will
-    # be blocked until the relation is established. This ensures upgrade hooks complete
-    # before we trigger temporal-k8s to process the new relation-joined hook.
-    juju.wait(lambda status: jubilant.all_blocked(status, ui_latest_track))
-
-    juju.integrate(
-        f"{TEMPORAL_SERVER_JUJU_APP}:temporal-host-info",
-        f"{ui_latest_track}:temporal-host-info",
-    )
-
+    # temporal-host-info is already integrated by the ui_latest_track fixture, so the
+    # refreshed charm should settle back to active without further intervention.
     juju.wait(jubilant.all_active, error=jubilant.any_error)


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

Due to the recent changes in the Temporal workload version, the refresh integration test must verify the upgrade path from a previous version to the newer one; therefore, this commit bumps the version from which we are deploying and refreshing from (replace latest/stable with 1.23/stable).

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

There are references to 1.23 channel, we need to change those in a separate PR once all the Temporal charms are released to 1.31.

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
