### PR TITLE
chore(tests): bump TEMPORAL_CHANNEL 1.23 -> 1.31

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,7 +16,7 @@ POSTGRESQL_K8S_CHANNEL = "14/stable"
 # Temporal charm channels. Bump these when the charms migrate to a new track
 # (e.g. 1.23 -> 1.31).
 TEMPORAL_CHANNEL = "1.31/edge"  # server/admin dependencies and the default ui deploy
-TEMPORAL_UI_LATEST_RELEASE_CHANNEL = "1.31/stable"  # published ui release the refresh test upgrades from
+TEMPORAL_UI_LATEST_RELEASE_CHANNEL = "1.23/stable"  # published ui release the refresh test upgrades from
 
 TEMPORAL_SERVER_JUJU_APP = "temporal-k8s"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -85,14 +85,14 @@ def deploy_temporal_stack(
         charm="temporal-admin-k8s",
         app="temporal-admin-k8s",
         channel=temporal_admin_channel,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
     )
 
     juju.deploy(
         charm="temporal-ui-k8s",
         app="temporal-ui-k8s",
         channel=temporal_ui_channel,
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
     )
 
     juju.wait(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,8 +15,8 @@ POSTGRESQL_K8S_CHANNEL = "14/stable"
 
 # Temporal charm channels. Bump these when the charms migrate to a new track
 # (e.g. 1.23 -> 1.31).
-TEMPORAL_CHANNEL = "1.23/edge"  # server/admin dependencies and the default ui deploy
-TEMPORAL_UI_LATEST_RELEASE_CHANNEL = "1.23/stable"  # published ui release the refresh test upgrades from
+TEMPORAL_CHANNEL = "1.31/edge"  # server/admin dependencies and the default ui deploy
+TEMPORAL_UI_LATEST_RELEASE_CHANNEL = "1.31/stable"  # published ui release the refresh test upgrades from
 
 TEMPORAL_SERVER_JUJU_APP = "temporal-k8s"
 

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -9,7 +9,7 @@ import jubilant
 
 logger = logging.getLogger(__name__)
 
-@pytest.skip("Skipping because of canonical/temporal-k8s-operator/issues/150")
+
 def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, ui_latest_track, charm_path, charm_resources):
     """Refresh from the latest supported temporal-ui-k8s release to the local build."""
     juju.refresh(

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -9,7 +9,7 @@ import jubilant
 
 logger = logging.getLogger(__name__)
 
-
+@pytest.skip("Skipping because of canonical/temporal-k8s-operator/issues/150")
 def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, ui_latest_track, charm_path, charm_resources):
     """Refresh from the latest supported temporal-ui-k8s release to the local build."""
     juju.refresh(


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->


Because of a new release, we need to test against the latest version of the charms.


---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
